### PR TITLE
Read, Update, Delete APIs for Samples

### DIFF
--- a/brainbeats-backend/Controllers/Sample.cs
+++ b/brainbeats-backend/Controllers/Sample.cs
@@ -25,7 +25,7 @@ namespace brainbeats_backend.Controllers
 			set;
 		}
 
-		public Boolean isPrivate
+		public bool? isPrivate
 		{
 			get;
 			set;

--- a/brainbeats-backend/Controllers/Sample.cs
+++ b/brainbeats-backend/Controllers/Sample.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace brainbeats_backend.Controllers
+{
+	public class Sample
+	{
+		public string id
+		{
+			get;
+			set;
+		}
+
+		public string authorId
+		{
+			get;
+			set;
+		}
+
+		public string name
+		{
+			get;
+			set;
+		}
+
+		public Boolean isPrivate
+		{
+			get;
+			set;
+		}
+
+		public string file
+		{
+			get;
+			set;
+		}
+
+		public string type
+		{
+			get;
+			set;
+		}
+	}
+}

--- a/brainbeats-backend/Controllers/SamplesController.cs
+++ b/brainbeats-backend/Controllers/SamplesController.cs
@@ -1,14 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Configuration;
+﻿using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration;
-using System.Net.Http;
 using System.Reflection;
 
 namespace brainbeats_backend.Controllers

--- a/brainbeats-backend/Controllers/SamplesController.cs
+++ b/brainbeats-backend/Controllers/SamplesController.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Configuration;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Configuration;
+using System.Net.Http;
+
+namespace brainbeats_backend.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class SamplesController : ControllerBase
+    {
+        private readonly Database db;
+
+        public SamplesController(IConfiguration configuration)
+        {
+            db = new DatabaseContext(configuration).db;
+        }
+
+        [Route("create")]
+        [HttpPost]
+        public HttpResponseMessage Create()
+        {
+            Console.WriteLine(HttpContext.Request.Form.ToString());
+
+            foreach (var formField in HttpContext.Request.Form)
+            {
+                Console.WriteLine(formField.Key);
+                Console.WriteLine(formField.Value);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
+}

--- a/brainbeats-backend/Controllers/SamplesController.cs
+++ b/brainbeats-backend/Controllers/SamplesController.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration;
 using System.Net.Http;
+using System.Reflection;
 
 namespace brainbeats_backend.Controllers
 {
@@ -23,19 +24,126 @@ namespace brainbeats_backend.Controllers
             db = new DatabaseContext(configuration).db;
         }
 
-        [Route("create")]
+        [Route("read")]
         [HttpPost]
-        public HttpResponseMessage Create()
+        public async Task<IActionResult>
+        ReadSample(Sample sample)
         {
-            Console.WriteLine(HttpContext.Request.Form.ToString());
-
-            foreach (var formField in HttpContext.Request.Form)
+            if (sample.id == null)
             {
-                Console.WriteLine(formField.Key);
-                Console.WriteLine(formField.Value);
+                return BadRequest("Malformed Request");
             }
 
-            return new HttpResponseMessage(HttpStatusCode.OK);
+            // Verify the sample with this ID exists
+            string queryString = "SELECT * FROM s WHERE s.id = @id";
+            QueryDefinition queryDefinition =
+                new QueryDefinition(queryString).WithParameter("@id", sample.id);
+
+            FeedIterator<Sample> feedIterator =
+                db.GetContainer("Samples").GetItemQueryIterator<Sample>(queryDefinition);
+
+            List<Sample> samples = new List<Sample>();
+
+            // Get the matching Sample with our ID
+            while (feedIterator.HasMoreResults)
+            {
+                FeedResponse<Sample> response = await feedIterator.ReadNextAsync();
+
+                foreach (Sample s in response)
+                {
+                    samples.Add(s);
+                }
+            }
+
+            if (samples.Count == 0)
+            {
+                return BadRequest("Sample not found");
+            }
+
+            return Ok(samples[0]);
+        }
+
+        [Route("update")]
+        [HttpPost]
+        public async Task<IActionResult>
+        UpdateSample(Sample sample)
+        {
+            if (sample.id == null)
+            {
+                return BadRequest("Malformed Request");
+            }
+
+            // Verify the sample with this ID exists
+            string queryString = "SELECT * FROM s WHERE s.id = @id";
+            QueryDefinition queryDefinition =
+                new QueryDefinition(queryString).WithParameter("@id", sample.id);
+
+            FeedIterator<Sample> feedIterator =
+                db.GetContainer("Samples").GetItemQueryIterator<Sample>(queryDefinition);
+
+            List<Sample> samples = new List<Sample>();
+
+            // Get the matching Sample with our ID
+            while (feedIterator.HasMoreResults)
+            {
+                FeedResponse<Sample> response = await feedIterator.ReadNextAsync();
+
+                foreach (Sample s in response)
+                {
+                    samples.Add(s);
+                }
+            }
+
+            if (samples.Count == 0)
+            {
+                return BadRequest("Sample not found");
+            }
+
+            Sample updatedSample = samples[0];
+
+            IList<PropertyInfo> properties = new List<PropertyInfo>(updatedSample.GetType().GetProperties());
+
+            foreach (var field in properties)
+            {
+                if (field.GetValue(sample, null) != null)
+                {
+                    field.SetValue(updatedSample, field.GetValue(sample, null));
+                }
+            }
+
+            ItemResponse<Sample> res = await db.GetContainer("Samples").ReplaceItemAsync(updatedSample, updatedSample.id, new PartitionKey(updatedSample.id));
+
+            if (res.StatusCode == HttpStatusCode.OK)
+            {
+                return Ok();
+            }
+            else
+            {
+                return BadRequest("Something went wrong");
+            }
+        }
+
+        [Route("delete")]
+        [HttpPost]
+        public async Task<IActionResult>
+        DeleteSample(Sample sample)
+        {
+            if (sample.id == null)
+            {
+                return BadRequest("Malformed Request");
+            }
+
+            // TODO: Give a real status code response for errors
+            try
+            {
+                ItemResponse<Sample> res = await db.GetContainer("Samples").DeleteItemAsync<Sample>(sample.id, new PartitionKey(sample.id));
+
+                return Ok();
+            }
+            catch (CosmosException e)
+            {
+                return BadRequest(e);
+            }
         }
     }
 }


### PR DESCRIPTION
Partial updates supported in Update, Read and Delete are straightforward queries

POST requests sent to the endpoints require a formatting that follows the Sample.cs class / Sample DB object. Fields can be omitted if they are not required. Extra fields can be added, but they won't be read by the APIs and discarded.

TODO: Need to add a better status response for failed deletions of items that don't exist