### PR TITLE
Refactor to make wrapper functions for most generic queries, add missing APIs

### DIFF
--- a/brainbeats-backend/.dockerignore
+++ b/brainbeats-backend/.dockerignore
@@ -1,2 +1,3 @@
 bin/
 obj/
+appsettings.json

--- a/brainbeats-backend/Controllers/BeatController.cs
+++ b/brainbeats-backend/Controllers/BeatController.cs
@@ -9,8 +9,7 @@ using static brainbeats_backend.Utility;
 namespace brainbeats_backend.Controllers {
   [Route("api/[controller]")]
   [ApiController]
-  public class BeatController : ControllerBase
-  {
+  public class BeatController : ControllerBase {
     [HttpPost]
     [Route("create_beat")]
     public async Task<IActionResult> CreateBeat(dynamic req) {
@@ -26,11 +25,11 @@ namespace brainbeats_backend.Controllers {
 
         queryString = CreateVertexQuery("beat", beatId, body, edges);
       } catch {
-        return BadRequest("Malformed Request");
+        return BadRequest("Malformed request");
       }
 
       try {
-        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
         return Ok(result);
       } catch {
         return BadRequest("Something went wrong");

--- a/brainbeats-backend/Controllers/BeatController.cs
+++ b/brainbeats-backend/Controllers/BeatController.cs
@@ -20,7 +20,7 @@ namespace brainbeats_backend.Controllers {
 
       try {
         string beatId = Guid.NewGuid().ToString();
-        List<KeyValuePair<string, string>> edges = new List<KeyValuePair<string, string>>() {
+        List<KeyValuePair<string, string>> edges = new List<KeyValuePair<string, string>> {
           new KeyValuePair<string, string>("OWNED_BY", body.GetValue("email").ToString())
         };
 

--- a/brainbeats-backend/Controllers/PlaylistController.cs
+++ b/brainbeats-backend/Controllers/PlaylistController.cs
@@ -21,13 +21,13 @@ namespace brainbeats_backend.Controllers
 
       try {
         string playlistId = Guid.NewGuid().ToString();
-        List<KeyValuePair<string, string>> edges = new List<KeyValuePair<string, string>>();
+        List<KeyValuePair<string, string>> edges = new List<KeyValuePair<string, string>> {
+          new KeyValuePair<string, string>("OWNED_BY", body.GetValue("email").ToString())
+        };
 
         if (body.ContainsKey("beatId")) {
           edges.Add(new KeyValuePair<string, string>("CONTAINS", body.GetValue("beatId").ToString()));
         }
-
-        edges.Add(new KeyValuePair<string, string>("OWNED_BY", body.GetValue("email").ToString()));
 
         queryString = CreateVertexQuery("playlist", playlistId, body, edges);
       } catch {

--- a/brainbeats-backend/Controllers/PlaylistController.cs
+++ b/brainbeats-backend/Controllers/PlaylistController.cs
@@ -71,7 +71,7 @@ namespace brainbeats_backend.Controllers
       string queryString;
 
       try {
-        queryString = GetOutNeighborsQuery("CONTAINS", "beat", body.GetValue("playlistId").ToString());
+        queryString = GetOutNeighborsQuery("beat", "CONTAINS", body.GetValue("playlistId").ToString());
       } catch {
         return BadRequest("Malformed request");
       }

--- a/brainbeats-backend/Controllers/SampleController.cs
+++ b/brainbeats-backend/Controllers/SampleController.cs
@@ -3,7 +3,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
-using static brainbeats_backend.Utility;
+using static brainbeats_backend.QueryBuilder;
 
 namespace brainbeats_backend.Controllers {
   [Route("api/[controller]")]

--- a/brainbeats-backend/Controllers/SampleController.cs
+++ b/brainbeats-backend/Controllers/SampleController.cs
@@ -1,9 +1,10 @@
 ﻿using System;
-using System.Text;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json;
-using static brainbeats_backend.QueryBuilder;
+using Newtonsoft.Json.Linq;
+using static brainbeats_backend.QueryStrings;
+using static brainbeats_backend.Utility;
 
 namespace brainbeats_backend.Controllers {
   [Route("api/[controller]")]
@@ -12,122 +13,124 @@ namespace brainbeats_backend.Controllers {
     [HttpPost]
     [Route("create_sample")]
     public async Task<IActionResult> CreateSample(dynamic req) {
-      string request = GetRequest(req);
-      var body = JsonConvert.DeserializeObject<dynamic>(request);
+      JObject body = DeserializeRequest(req);
 
-      string sampleId = Guid.NewGuid().ToString();
-      string name = body.name;
-      string email = body.email;
-
-      string isPrivate = body.isPrivate;
-      string attributes = body.attributes;
-      string audio = body.audio;
-      string modifiedDate = GetCurrentTime();
-      string seed = body.seed;
-
-      StringBuilder queryString = new StringBuilder();
+      string queryString;
 
       try {
-        queryString.Append(CreateVertex("sample", sampleId) +
-          AddProperty("name", name) +
-          AddProperty("isPrivate", isPrivate) +
-          AddProperty("attributes", attributes) +
-          AddProperty("audio", audio) +
-          AddProperty("modifiedDate", modifiedDate) +
-          CreateEdge("OWNED_BY", email));
+        string sampleId = Guid.NewGuid().ToString();
+        List<KeyValuePair<string, string>> edges = new List<KeyValuePair<string, string>>() {
+          new KeyValuePair<string, string>("OWNED_BY", body.GetValue("email").ToString())
+        };
+
+        queryString = CreateVertexQuery("sample", sampleId, body, edges);
       } catch {
-        return BadRequest();
-      }
-
-      if (seed != null) {
-        queryString.Append(EdgeSourceReference() + AddProperty("seed", seed, false));
+        return BadRequest("Malformed request");
       }
 
       try {
-        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
-
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
         return Ok(result);
       } catch {
-        return BadRequest();
+        return BadRequest("Something went wrong");
       }
     }
 
     [HttpPost]
     [Route("read_sample")]
     public async Task<IActionResult> ReadSample(dynamic req) {
-      string request = GetRequest(req);
-      var body = JsonConvert.DeserializeObject<dynamic>(request);
+      JObject body = DeserializeRequest(req);
 
-      string sampleId = body.sampleId;
+      string queryString;
 
-      if (sampleId == null) {
-        return BadRequest("Malformed Request");
+      try {
+        queryString = ReadVertexQuery(body.GetValue("sampleId").ToString());
+      } catch {
+        return BadRequest("Malformed request");
       }
-
-      string queryString = GetVertex(sampleId);
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
         return Ok(result);
       } catch {
-        return BadRequest();
+        return BadRequest("Something went wrong");
+      }
+    }
+
+    [HttpPost]
+    [Route("get_all_samples")]
+    public async Task<IActionResult> GetAllSamples(dynamic req) {
+      JObject body = DeserializeRequest(req);
+
+      string queryStringPublic;
+      string queryStringPrivate;
+
+      try {
+        queryStringPublic = GetAllPublicVerticesQuery("sample");
+        queryStringPrivate = GetAllPrivateVerticesQuery("sample", body.GetValue("email").ToString());
+      } catch {
+        return BadRequest("Malformed Request");
+      }
+
+      try {
+        var resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
+        var resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
+
+        List<dynamic> resultList = new List<dynamic>();
+
+        foreach (var item in resultsPublic) {
+          resultList.Add(item);
+        }
+
+        foreach (var item in resultsPrivate) {
+          resultList.Add(item);
+        }
+
+        return Ok(resultList);
+      } catch {
+        return BadRequest("Something went wrong");
       }
     }
 
     [HttpPost]
     [Route("update_sample")]
     public async Task<IActionResult> UpdateSample(dynamic req) {
-      string request = GetRequest(req);
-      var body = JsonConvert.DeserializeObject<dynamic>(request);
+      JObject body = DeserializeRequest(req);
 
-      string sampleId = body.sampleId;
-      string name = body.name;
-      string isPrivate = body.isPrivate;
-      string attributes = body.attributes;
-      string audio = body.audio;
-      string modifiedDate = GetCurrentTime();
-
-      StringBuilder queryString = new StringBuilder();
-      bool required = false;
+      string queryString;
 
       try {
-        queryString.Append(GetVertex(sampleId) +
-          AddProperty("name", name, required) +
-          AddProperty("isPrivate", isPrivate, required) +
-          AddProperty("attributes", attributes, required) +
-          AddProperty("audio", audio, required) +
-          AddProperty("modifiedDate", modifiedDate));
+        queryString = UpdateVertexQuery("sample", body.GetValue("sampleId").ToString(), body);
       } catch {
-        return BadRequest();
+        return BadRequest("Malformed request");
       }
 
       try {
-        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
         return Ok(result);
       } catch {
-        return BadRequest();
+        return BadRequest("Something went wrong");
       }
     }
 
     [HttpPost]
     [Route("delete_sample")]
     public async Task<IActionResult> DeleteSample(dynamic req) {
-      string request = GetRequest(req);
-      var body = JsonConvert.DeserializeObject<dynamic>(request);
+      JObject body = DeserializeRequest(req);
 
-      string sampleId = body.sampleId;
+      string queryString;
 
-      if (sampleId == null) {
-        return BadRequest("Malformed Request");
+      try {
+        queryString = DeleteVertexQuery(body.GetValue("sampleId").ToString());
+      } catch {
+        return BadRequest("Malformed request");
       }
-
-      string queryString = GetVertex(sampleId) + Delete();
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
         return Ok(result);
       } catch {
-        return BadRequest();
+        return BadRequest("Something went wrong");
       }
     }
   }

--- a/brainbeats-backend/Controllers/SampleController.cs
+++ b/brainbeats-backend/Controllers/SampleController.cs
@@ -19,7 +19,7 @@ namespace brainbeats_backend.Controllers {
 
       try {
         string sampleId = Guid.NewGuid().ToString();
-        List<KeyValuePair<string, string>> edges = new List<KeyValuePair<string, string>>() {
+        List<KeyValuePair<string, string>> edges = new List<KeyValuePair<string, string>> {
           new KeyValuePair<string, string>("OWNED_BY", body.GetValue("email").ToString())
         };
 

--- a/brainbeats-backend/Controllers/SeedController.cs
+++ b/brainbeats-backend/Controllers/SeedController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -30,105 +31,154 @@ namespace brainbeats_backend.Controllers
 
       try {
         await DeleteSeed(deleteSeedObject.ToString()).ConfigureAwait(false);
+
+        System.Threading.Thread.Sleep(5000);
       } catch {
         return BadRequest("Error deleting prior seed");
       }
 
-      // User 1
-      JObject userObject1 =
-        new JObject(
-          new JProperty("firstName", $"test_first_name_{seed}"),
-          new JProperty("lastName", $"test_last_name_{seed}"),
-          new JProperty("email", $"test_email_1_{seed}@email.com"),
-          new JProperty("seed", seed));
-
-      // User 1 owns this sample
-      JObject sampleObject1a =
-        new JObject(
-          new JProperty("name", "test_sample_name_1"),
-          new JProperty("email", $"test_email_1_{seed}@email.com"),
-          new JProperty("isPrivate", "false"),
-          new JProperty("attributes", "test_sample_attributes_1"),
-          new JProperty("audio", "test_sample_audio_1"),
-          new JProperty("seed", seed));
-
-      // User 1 owns this sample
-      JObject sampleObject1b =
-        new JObject(
-          new JProperty("name", "test_sample_name_2"),
-          new JProperty("email", $"test_email_1_{seed}@email.com"),
-          new JProperty("isPrivate", "false"),
-          new JProperty("attributes", "test_sample_attributes_2"),
-          new JProperty("audio", "test_sample_audio_2"),
-          new JProperty("seed", seed));
-
-      // User 1 owns this beat
-      JObject beatObject1a =
-        new JObject(
-          new JProperty("name", "test_beat_name_1"),
-          new JProperty("email", $"test_email_1_{seed}@email.com"),
-          new JProperty("isPrivate", "true"),
-          new JProperty("duration", "test_beat_duration_1"),
-          new JProperty("image", "test_beat_duration_1"),
-          new JProperty("instrumentList", "test_beat_instrument_list_1"),
-          new JProperty("attributes", "test_beat_attributes_1"),
-          new JProperty("audio", "test_beat_audio_1"),
-          new JProperty("seed", seed));
-
-      // User 1 owns this beat
-      JObject beatObject1b =
-        new JObject(
-          new JProperty("name", "test_beat_name_2"),
-          new JProperty("email", $"test_email_1_{seed}@email.com"),
-          new JProperty("isPrivate", "false"),
-          new JProperty("duration", "test_beat_duration_2"),
-          new JProperty("image", "test_beat_duration_2"),
-          new JProperty("instrumentList", "test_beat_instrument_list_2"),
-          new JProperty("attributes", "test_beat_attributes_2"),
-          new JProperty("audio", "test_beat_audio_2"),
-          new JProperty("seed", seed));
-
-      string beatId1a;
-
       try {
-        await new UserController().CreateUser(userObject1.ToString());
-        await new SampleController().CreateSample(sampleObject1a.ToString());
-        await new SampleController().CreateSample(sampleObject1b.ToString());
+        for (int user = 0; user < 1; user++) {
+          JObject userObject =
+            new JObject(
+              new JProperty("firstName", $"test_first_name_{user}_{seed}"),
+              new JProperty("lastName", $"test_last_name_{user}_{seed}"),
+              new JProperty("email", $"test_email_{user}_{seed}@email.com"),
+              new JProperty("seed", seed));
 
-        IActionResult resSet = await new BeatController().CreateBeat(beatObject1a.ToString());
-        OkObjectResult okResult = resSet as OkObjectResult;
+          await new UserController().CreateUser(userObject.ToString());
 
-        IEnumerable<dynamic> resEnum = okResult.Value as IEnumerable<dynamic>;
-        beatId1a = resEnum.First()["id"];
+          List<JObject> beatList = new List<JObject>();
+          List<JObject> sampleList = new List<JObject>();
 
-        await new BeatController().CreateBeat(beatObject1b.ToString());
-      } catch {
-        return BadRequest("Error creating base vertices and edges");
-      }
+          for (int beat = 0; beat < 5; beat++) {
+            // User 1 owns this beat
+            JObject beatObject =
+              new JObject(
+                new JProperty("name", $"test_beat_{user}_{beat}"),
+                new JProperty("email", $"test_email_{user}_{seed}@email.com"),
+                new JProperty("isPrivate", "false"),
+                new JProperty("attributes", "{}"),
+                new JProperty("audio", $"test_beat_audio_{user}_{beat}"),
+                new JProperty("instrumentList", $"test_beat_instrumentList_{user}_{beat}"),
+                new JProperty("duration", $"test_beat_duration_{user}_{beat}"),
+                new JProperty("image", $"test_beat_image_{user}_{beat}"),
+                new JProperty("seed", seed));
 
-      // User 1 likes this beat
-      JObject likeBeatObject1a =
-        new JObject(
-          new JProperty("vertexId", beatId1a),
-          new JProperty("email", $"test_email_1_{seed}@email.com"));
+            beatList.Add(beatObject);
+          }
 
-      // User 1 owns this playlist consisting of the prior created beat
-      JObject playlistObject1a =
-        new JObject(
-          new JProperty("name", "test_playlist_name_1"),
-          new JProperty("email", $"test_email_1_{seed}@email.com"),
-          new JProperty("isPrivate", "false"),
-          new JProperty("image", "test_playlist_image_1"),
-          new JProperty("beatId", beatId1a),
-          new JProperty("seed", seed));
+          for (int sample = 0; sample < 2; sample++) {
+            JObject sampleObject =
+              new JObject(
+                new JProperty("name", $"test_sample_{user}_{sample}"),
+                new JProperty("email", $"test_email_{user}_{seed}@email.com"),
+                new JProperty("isPrivate", "false"),
+                new JProperty("attributes", "{}"),
+                new JProperty("audio", $"test_beat_audio_{user}_{sample}"),
+                new JProperty("seed", seed));
 
-      try {
-        await new UserController().LikeVertex(likeBeatObject1a.ToString());
-        await new PlaylistController().CreatePlaylist(playlistObject1a.ToString());
+            sampleList.Add(sampleObject);
+          }
+
+          List<string> beatIds = new List<string>();
+          List<string> sampleIds = new List<string>();
+
+          foreach (JObject obj in beatList) {
+            IActionResult resSet = await new BeatController().CreateBeat(obj.ToString());
+            OkObjectResult okResult = resSet as OkObjectResult;
+
+            IEnumerable<dynamic> resEnum = okResult.Value as IEnumerable<dynamic>;
+            string beatId = resEnum.First()["id"];
+
+            beatIds.Add(beatId);
+
+            System.Threading.Thread.Sleep(1000);
+          }
+
+          foreach (JObject obj in sampleList) {
+            IActionResult resSet = await new SampleController().CreateSample(obj.ToString());
+            OkObjectResult okResult = resSet as OkObjectResult;
+
+            IEnumerable<dynamic> resEnum = okResult.Value as IEnumerable<dynamic>;
+            string sampleId = resEnum.First()["id"];
+
+            sampleIds.Add(sampleId);
+
+            System.Threading.Thread.Sleep(1000);
+          }
+
+          Console.WriteLine(sampleIds.ToString());
+
+          string playlistEvensId = "";
+          string playlistOddsId = "";
+
+          for (int i = 0; i < beatIds.Count(); i++) {
+            // Even numbers belong in playlist 1, odd numbers belong in playlist 2
+            if (i % 2 == 0) {
+              if (i == 0) {
+                JObject playlistObject =
+                  new JObject(
+                    new JProperty("name", $"test_playlist_name_{user}_{i}"),
+                    new JProperty("email", $"test_email_{user}_{seed}@email.com"),
+                    new JProperty("isPrivate", "false"),
+                    new JProperty("image", $"test_playlist_image_{user}_{i}"),
+                    new JProperty("beatId", beatIds[i]),
+                    new JProperty("seed", seed));
+
+                IActionResult resSet = await new PlaylistController().CreatePlaylist(playlistObject.ToString());
+                OkObjectResult okResult = resSet as OkObjectResult;
+
+                IEnumerable<dynamic> resEnum = okResult.Value as IEnumerable<dynamic>;
+                playlistEvensId = resEnum.First()["id"];
+              } else {
+                JObject addBeatToPlaylistObject =
+                  new JObject(
+                    new JProperty("beatId", beatIds[i]),
+                    new JProperty("playlistId", playlistEvensId));
+                await new PlaylistController().UpdatePlaylistAddBeat(addBeatToPlaylistObject.ToString());
+              }
+            } else {
+              if (i == 1) {
+                JObject playlistObject =
+                  new JObject(
+                    new JProperty("name", $"test_playlist_name_{user}_{i}"),
+                    new JProperty("email", $"test_email_{user}_{seed}@email.com"),
+                    new JProperty("isPrivate", "false"),
+                    new JProperty("image", $"test_playlist_image_{user}_{i}"),
+                    new JProperty("beatId", beatIds[i]),
+                    new JProperty("seed", seed));
+
+                IActionResult resSet = await new PlaylistController().CreatePlaylist(playlistObject.ToString());
+                OkObjectResult okResult = resSet as OkObjectResult;
+
+                IEnumerable<dynamic> resEnum = okResult.Value as IEnumerable<dynamic>;
+                playlistOddsId = resEnum.First()["id"];
+              } else {
+                JObject addBeatToPlaylistObject =
+                  new JObject(
+                    new JProperty("beatId", beatIds[i]),
+                    new JProperty("playlistId", playlistOddsId));
+                await new PlaylistController().UpdatePlaylistAddBeat(addBeatToPlaylistObject.ToString());
+              }
+            }
+
+            System.Threading.Thread.Sleep(1000);
+
+            JObject likeBeatObject =
+              new JObject(
+                new JProperty("vertexId", beatIds[i]),
+                new JProperty("email", $"test_email_{user}_{seed}@email.com"));
+
+            await new UserController().LikeVertex(likeBeatObject.ToString());
+
+            System.Threading.Thread.Sleep(1000);
+          }
+        }
 
         return Ok();
       } catch {
-        return BadRequest("Error creating extra vertices and edges");
+        return BadRequest("Error");
       }
     }
 

--- a/brainbeats-backend/Controllers/SeedController.cs
+++ b/brainbeats-backend/Controllers/SeedController.cs
@@ -108,8 +108,6 @@ namespace brainbeats_backend.Controllers
             System.Threading.Thread.Sleep(1000);
           }
 
-          Console.WriteLine(sampleIds.ToString());
-
           string playlistEvensId = "";
           string playlistOddsId = "";
 

--- a/brainbeats-backend/Controllers/SeedController.cs
+++ b/brainbeats-backend/Controllers/SeedController.cs
@@ -10,7 +10,7 @@ namespace brainbeats_backend.Controllers
 {
   [Route("api/[controller]")]
   [ApiController]
-  public class TestController : ControllerBase
+  public class SeedController : ControllerBase
   {
     [HttpPost]
     [Route("create")]

--- a/brainbeats-backend/Controllers/TestController.cs
+++ b/brainbeats-backend/Controllers/TestController.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using static brainbeats_backend.QueryBuilder;
+using static brainbeats_backend.Utility;
 
 namespace brainbeats_backend.Controllers
 {
@@ -16,14 +15,13 @@ namespace brainbeats_backend.Controllers
     [HttpPost]
     [Route("create")]
     public async Task<IActionResult> CreateSeed(dynamic req) {
-      string request = GetRequest(req);
-      var body = JsonConvert.DeserializeObject<dynamic>(request);
+      JObject body = DeserializeRequest(req);
 
-      string seed = body.seed;
-
-      if (seed == null) {
+      if (!body.ContainsKey("seed")) {
         return BadRequest("Malformed Request");
       }
+
+      string seed = body.GetValue("seed").ToString();
 
       // Delete the current seed if it exists
       JObject deleteSeedObject =
@@ -41,7 +39,7 @@ namespace brainbeats_backend.Controllers
         new JObject(
           new JProperty("firstName", $"test_first_name_{seed}"),
           new JProperty("lastName", $"test_last_name_{seed}"),
-          new JProperty("id", $"test_email_1_{seed}@email.com"),
+          new JProperty("email", $"test_email_1_{seed}@email.com"),
           new JProperty("seed", seed));
 
       // User 1 owns this sample

--- a/brainbeats-backend/Controllers/TestController.cs
+++ b/brainbeats-backend/Controllers/TestController.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using static brainbeats_backend.Utility;
+using static brainbeats_backend.QueryBuilder;
 
 namespace brainbeats_backend.Controllers
 {
@@ -41,7 +41,7 @@ namespace brainbeats_backend.Controllers
         new JObject(
           new JProperty("firstName", $"test_first_name_{seed}"),
           new JProperty("lastName", $"test_last_name_{seed}"),
-          new JProperty("email", $"test_email_1_{seed}@email.com"),
+          new JProperty("id", $"test_email_1_{seed}@email.com"),
           new JProperty("seed", seed));
 
       // User 1 owns this sample
@@ -69,7 +69,7 @@ namespace brainbeats_backend.Controllers
         new JObject(
           new JProperty("name", "test_beat_name_1"),
           new JProperty("email", $"test_email_1_{seed}@email.com"),
-          new JProperty("isPrivate", "false"),
+          new JProperty("isPrivate", "true"),
           new JProperty("duration", "test_beat_duration_1"),
           new JProperty("image", "test_beat_duration_1"),
           new JProperty("instrumentList", "test_beat_instrument_list_1"),
@@ -111,7 +111,7 @@ namespace brainbeats_backend.Controllers
       // User 1 likes this beat
       JObject likeBeatObject1a =
         new JObject(
-          new JProperty("beatId", beatId1a),
+          new JProperty("vertexId", beatId1a),
           new JProperty("email", $"test_email_1_{seed}@email.com"));
 
       // User 1 owns this playlist consisting of the prior created beat
@@ -125,7 +125,7 @@ namespace brainbeats_backend.Controllers
           new JProperty("seed", seed));
 
       try {
-        await new BeatController().LikeBeat(likeBeatObject1a.ToString());
+        await new UserController().LikeVertex(likeBeatObject1a.ToString());
         await new PlaylistController().CreatePlaylist(playlistObject1a.ToString());
 
         return Ok();

--- a/brainbeats-backend/Controllers/UserController.cs
+++ b/brainbeats-backend/Controllers/UserController.cs
@@ -1,33 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.VisualBasic.CompilerServices;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using static brainbeats_backend.QueryBuilder;
 using static brainbeats_backend.QueryStrings;
 using static brainbeats_backend.Utility;
 
 namespace brainbeats_backend.Controllers {
   [Route("api/[controller]")]
   [ApiController]
-  public class UserController : ControllerBase
-  {
-    HashSet<string> schema = GetSchema("user");
-
+  public class UserController : ControllerBase {
     [HttpPost]
     [Route("create_user")]
     public async Task<IActionResult> CreateUser(dynamic req) {
       JObject body = DeserializeRequest(req);
 
-      if (!body.ContainsKey("email")) {
+      string queryString;
+
+      try {
+        queryString = CreateVertexQuery("user", body.GetValue("email").ToString(), body);
+      } catch {
         return BadRequest("Malformed request");
       }
-
-      string queryString = CreateVertexQuery("user", body.GetValue("email").ToString(), body);
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
@@ -42,11 +34,13 @@ namespace brainbeats_backend.Controllers {
     public async Task<IActionResult> ReadUser(dynamic req) {
       JObject body = DeserializeRequest(req);
 
-      if (!body.ContainsKey("email")) {
+      string queryString;
+
+      try {
+        queryString = ReadVertexQuery(body.GetValue("email").ToString());
+      } catch {
         return BadRequest("Malformed request");
       }
-
-      string queryString = ReadVertexQuery(body.GetValue("email").ToString());
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
@@ -61,14 +55,10 @@ namespace brainbeats_backend.Controllers {
     public async Task<IActionResult> UpdateUser(dynamic req) {
       JObject body = DeserializeRequest(req);
 
-      if (!body.ContainsKey("email")) {
-        return BadRequest("Malformed Request");
-      }
-
       string queryString;
 
       try {
-        queryString = UpdateVertexQuery("user", body.GetValue("email").ToString(), body));
+        queryString = UpdateVertexQuery("user", body.GetValue("email").ToString(), body);
       } catch {
         return BadRequest("Malformed Request");
       }
@@ -85,95 +75,188 @@ namespace brainbeats_backend.Controllers {
     [Route("delete_user")]
     public async Task<IActionResult> DeleteUser(dynamic req) {
       JObject body = DeserializeRequest(req);
-      return await new BaseGremlinTemplate().DeleteVertex(body.GetValue("id"));
-    }
 
-    [HttpPost]
-    [Route("get_liked_beats")]
-    public async Task<IActionResult> GetLikedBeats(dynamic req) {
-      var body = DeserializeRequest(req);
+      string queryString;
 
-      string email = body.email;
-
-      if (email == null) {
-        return BadRequest("Malformed Request");
+      try {
+        queryString = DeleteVertexQuery(body.GetValue("email").ToString());
+      } catch {
+        return BadRequest("Malformed request");
       }
-
-      string queryString = GetLikedVerticesQuery("beat", email);
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
         return Ok(result);
       } catch {
-        return BadRequest();
+        return BadRequest("Something went wrong");
+      }
+    }
+
+    [HttpPost]
+    [Route("get_liked_beats")]
+    public async Task<IActionResult> GetLikedBeats(dynamic req) {
+      JObject body = DeserializeRequest(req);
+
+      string queryString;
+
+      try {
+        queryString = GetOutNeighborsQuery("beat", "LIKES", body.GetValue("email").ToString());
+      } catch {
+        return BadRequest("Malformed Request");
+      }
+
+      try {
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+        return Ok(result);
+      } catch {
+        return BadRequest("Something went wrong");
+      }
+    }
+
+    [HttpPost]
+    [Route("get_liked_playlists")]
+    public async Task<IActionResult> GetLikedPlaylists(dynamic req) {
+      JObject body = DeserializeRequest(req);
+
+      string queryString;
+
+      try {
+        queryString = GetOutNeighborsQuery("playlist", "LIKES", body.GetValue("email").ToString());
+      } catch {
+        return BadRequest("Malformed Request");
+      }
+
+      try {
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+        return Ok(result);
+      } catch {
+        return BadRequest("Something went wrong");
+      }
+    }
+
+    [HttpPost]
+    [Route("get_liked_samples")]
+    public async Task<IActionResult> GetLikedSamples(dynamic req) {
+      JObject body = DeserializeRequest(req);
+
+      string queryString;
+
+      try {
+        queryString = GetOutNeighborsQuery("sample", "LIKES", body.GetValue("email").ToString());
+      } catch {
+        return BadRequest("Malformed Request");
+      }
+
+      try {
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+        return Ok(result);
+      } catch {
+        return BadRequest("Something went wrong");
       }
     }
 
     [HttpPost]
     [Route("get_owned_beats")]
     public async Task<IActionResult> GetOwnedBeats(dynamic req) {
-      var body = DeserializeRequest(req);
+      JObject body = DeserializeRequest(req);
 
-      string email = body.email;
+      string queryString;
 
-      if (email == null) {
+      try {
+        queryString = GetInNeighborsQuery("beat", "OWNED_BY", body.GetValue("email").ToString());
+      } catch {
         return BadRequest("Malformed Request");
       }
-
-      string queryString = GetOwnedVerticesQuery("beat", email);
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
         return Ok(result);
       } catch {
-        return BadRequest();
+        return BadRequest("Something went wrong");
+      }
+    }
+
+    [HttpPost]
+    [Route("get_owned_playlists")]
+    public async Task<IActionResult> GetOwnedPlaylists(dynamic req) {
+      JObject body = DeserializeRequest(req);
+
+      string queryString;
+
+      try {
+        queryString = GetInNeighborsQuery("playlist", "OWNED_BY", body.GetValue("email").ToString());
+      } catch {
+        return BadRequest("Malformed Request");
+      }
+
+      try {
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+        return Ok(result);
+      } catch {
+        return BadRequest("Something went wrong");
+      }
+    }
+
+    [HttpPost]
+    [Route("get_owned_samples")]
+    public async Task<IActionResult> GetOwnedSamples(dynamic req) {
+      JObject body = DeserializeRequest(req);
+
+      string queryString;
+
+      try {
+        queryString = GetInNeighborsQuery("sample", "OWNED_BY", body.GetValue("email").ToString());
+      } catch {
+        return BadRequest("Malformed Request");
+      }
+
+      try {
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+        return Ok(result);
+      } catch {
+        return BadRequest("Something went wrong");
       }
     }
 
     [HttpPost]
     [Route("like_vertex")]
     public async Task<IActionResult> LikeVertex(dynamic req) {
-      var body = DeserializeRequest(req);
+      JObject body = DeserializeRequest(req);
 
-      string vertexId = body.vertexId;
-      string email = body.email;
+      string queryString;
 
-      if (vertexId == null || email == null) {
-        return BadRequest("Malformed Request");
+      try {
+        queryString = CreateOutNeighborQuery("LIKES", body.GetValue("email").ToString(), body.GetValue("vertexId").ToString());
+      } catch {
+        return BadRequest("Malformed request");
       }
-
-      string queryString = GetVertex(email) +
-        CreateEdge("LIKES", vertexId);
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
         return Ok(result);
       } catch {
-        return BadRequest();
+        return BadRequest("Something went wrong");
       }
     }
 
     [HttpPost]
     [Route("unlike_vertex")]
     public async Task<IActionResult> UnlikeVertex(dynamic req) {
-      var body = DeserializeRequest(req);
+      JObject body = DeserializeRequest(req);
 
-      string vertexId = body.vertexId;
-      string email = body.email;
+      string queryString;
 
-      if (vertexId == null || email == null) {
-        return BadRequest("Malformed Request");
+      try {
+        queryString = DeleteOutNeighborQuery("LIKES", body.GetValue("email").ToString(), body.GetValue("vertexId").ToString());
+      } catch {
+        return BadRequest("Malformed request");
       }
-
-      string queryString = GetVertex(email) +
-        GetEdge("LIKES", vertexId) +
-        Delete();
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
         return Ok(result);
       } catch {
-        return BadRequest();
+        return BadRequest("Something went wrong");
       }
     }
   }

--- a/brainbeats-backend/Controllers/UserController.cs
+++ b/brainbeats-backend/Controllers/UserController.cs
@@ -1,8 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.VisualBasic.CompilerServices;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using static brainbeats_backend.QueryBuilder;
+using static brainbeats_backend.QueryStrings;
 using static brainbeats_backend.Utility;
 
 namespace brainbeats_backend.Controllers {
@@ -10,44 +16,82 @@ namespace brainbeats_backend.Controllers {
   [ApiController]
   public class UserController : ControllerBase
   {
+    HashSet<string> schema = GetSchema("user");
+
     [HttpPost]
     [Route("create_user")]
     public async Task<IActionResult> CreateUser(dynamic req) {
-      string request = GetRequest(req);
-      var body = JsonConvert.DeserializeObject<dynamic>(request);
+      JObject body = DeserializeRequest(req);
 
-      string firstName = body.firstName;
-      string lastName = body.lastName;
-      string email = body.email;
-      string seed = body.seed;
-
-      StringBuilder queryString = new StringBuilder();
-
-      try {
-        queryString.Append(CreateVertex("user", email) +
-          AddProperty("firstName", firstName) +
-          AddProperty("lastName", lastName));
-      } catch {
-        return BadRequest("Malformed Request");
+      if (!body.ContainsKey("email")) {
+        return BadRequest("Malformed request");
       }
 
-      if (seed != null) {
-        queryString.Append(AddProperty("seed", seed, false));
-      }
+      string queryString = CreateVertexQuery("user", body.GetValue("email").ToString(), body);
 
       try {
-        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
         return Ok(result);
       } catch {
-        return BadRequest();
+        return BadRequest("Something went wrong");
       }
     }
 
     [HttpPost]
     [Route("read_user")]
     public async Task<IActionResult> ReadUser(dynamic req) {
-      string request = GetRequest(req);
-      var body = JsonConvert.DeserializeObject<dynamic>(request);
+      JObject body = DeserializeRequest(req);
+
+      if (!body.ContainsKey("email")) {
+        return BadRequest("Malformed request");
+      }
+
+      string queryString = ReadVertexQuery(body.GetValue("email").ToString());
+
+      try {
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+        return Ok(result);
+      } catch {
+        return BadRequest("Something went wrong");
+      }
+    }
+
+    [HttpPost]
+    [Route("update_user")]
+    public async Task<IActionResult> UpdateUser(dynamic req) {
+      JObject body = DeserializeRequest(req);
+
+      if (!body.ContainsKey("email")) {
+        return BadRequest("Malformed Request");
+      }
+
+      string queryString;
+
+      try {
+        queryString = UpdateVertexQuery("user", body.GetValue("email").ToString(), body));
+      } catch {
+        return BadRequest("Malformed Request");
+      }
+
+      try {
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+        return Ok(result);
+      } catch {
+        return BadRequest("Something went wrong");
+      }
+    }
+
+    [HttpPost]
+    [Route("delete_user")]
+    public async Task<IActionResult> DeleteUser(dynamic req) {
+      JObject body = DeserializeRequest(req);
+      return await new BaseGremlinTemplate().DeleteVertex(body.GetValue("id"));
+    }
+
+    [HttpPost]
+    [Route("get_liked_beats")]
+    public async Task<IActionResult> GetLikedBeats(dynamic req) {
+      var body = DeserializeRequest(req);
 
       string email = body.email;
 
@@ -55,7 +99,7 @@ namespace brainbeats_backend.Controllers {
         return BadRequest("Malformed Request");
       }
 
-      string queryString = GetVertex(email);
+      string queryString = GetLikedVerticesQuery("beat", email);
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
@@ -66,39 +110,9 @@ namespace brainbeats_backend.Controllers {
     }
 
     [HttpPost]
-    [Route("update_user")]
-    public async Task<IActionResult> UpdateUser(dynamic req) {
-      string request = Utility.GetRequest(req);
-      var body = JsonConvert.DeserializeObject<dynamic>(request);
-
-      string email = body.email;
-      string firstName = body.firstName;
-      string lastName = body.lastName;
-
-      StringBuilder queryString = new StringBuilder();
-      bool required = false;
-
-      try {
-        queryString.Append(GetVertex(email) +
-          AddProperty("firstName", firstName, required) +
-          AddProperty("lastName", lastName, required));
-      } catch {
-        return BadRequest("Malformed Request");
-      }
-
-      try {
-        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
-        return Ok(result);
-      } catch {
-        return BadRequest();
-      }
-    }
-
-    [HttpPost]
-    [Route("delete_user")]
-    public async Task<IActionResult> DeleteUser(dynamic req) {
-      string request = GetRequest(req);
-      var body = JsonConvert.DeserializeObject<dynamic>(request);
+    [Route("get_owned_beats")]
+    public async Task<IActionResult> GetOwnedBeats(dynamic req) {
+      var body = DeserializeRequest(req);
 
       string email = body.email;
 
@@ -106,7 +120,54 @@ namespace brainbeats_backend.Controllers {
         return BadRequest("Malformed Request");
       }
 
-      string queryString = GetVertex(email) + Delete();
+      string queryString = GetOwnedVerticesQuery("beat", email);
+
+      try {
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+        return Ok(result);
+      } catch {
+        return BadRequest();
+      }
+    }
+
+    [HttpPost]
+    [Route("like_vertex")]
+    public async Task<IActionResult> LikeVertex(dynamic req) {
+      var body = DeserializeRequest(req);
+
+      string vertexId = body.vertexId;
+      string email = body.email;
+
+      if (vertexId == null || email == null) {
+        return BadRequest("Malformed Request");
+      }
+
+      string queryString = GetVertex(email) +
+        CreateEdge("LIKES", vertexId);
+
+      try {
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+        return Ok(result);
+      } catch {
+        return BadRequest();
+      }
+    }
+
+    [HttpPost]
+    [Route("unlike_vertex")]
+    public async Task<IActionResult> UnlikeVertex(dynamic req) {
+      var body = DeserializeRequest(req);
+
+      string vertexId = body.vertexId;
+      string email = body.email;
+
+      if (vertexId == null || email == null) {
+        return BadRequest("Malformed Request");
+      }
+
+      string queryString = GetVertex(email) +
+        GetEdge("LIKES", vertexId) +
+        Delete();
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);

--- a/brainbeats-backend/DatabaseConnection.cs
+++ b/brainbeats-backend/DatabaseConnection.cs
@@ -33,7 +33,7 @@ namespace brainbeats_backend {
 
     public Task<ResultSet<dynamic>> ExecuteQuery(string query) {
       try {
-          return gremlinClient.SubmitAsync<dynamic>(query);
+         return gremlinClient.SubmitAsync<dynamic>(query);
       } catch (ResponseException e) {
         Console.WriteLine("\tRequest Error!");
 

--- a/brainbeats-backend/DatabaseConnection.cs
+++ b/brainbeats-backend/DatabaseConnection.cs
@@ -33,7 +33,7 @@ namespace brainbeats_backend {
 
     public Task<ResultSet<dynamic>> ExecuteQuery(string query) {
       try {
-         return gremlinClient.SubmitAsync<dynamic>(query);
+        return gremlinClient.SubmitAsync<dynamic>(query);
       } catch (ResponseException e) {
         Console.WriteLine("\tRequest Error!");
 

--- a/brainbeats-backend/QueryBuilder.cs
+++ b/brainbeats-backend/QueryBuilder.cs
@@ -1,0 +1,85 @@
+﻿using System;
+
+namespace brainbeats_backend {
+  public static class QueryBuilder {
+    // Creates a new vertex with the partitioning key "type"
+    public static string CreateVertex(string vertexType, string vertexId) {
+      return $"g.addV('{vertexType}')" + 
+        AddProperty("type", vertexType) + 
+        AddProperty("id", vertexId);
+    }
+
+    public static string CreateVertex(string vertexType) {
+      return $"g.addV('{vertexType}')" + AddProperty("type", vertexType);
+    }
+
+    // Deletes the current vertex or edge
+    public static string Delete() {
+      return $".drop()";
+    }
+
+    // Returns the specified vertex by key
+    public static string GetVertex(string vertexId) {
+      return $"g.V('{vertexId}')";
+    }
+
+    // Returns all vertices of a given type
+    public static string GetAllVertices(string vertexType) {
+      return $"g.V().hasLabel('{vertexType}')";
+    }
+
+    // Creates a new edge and adds the current time as a property
+    public static string CreateEdge(string edgeType, string dest) {
+      return $".addE('{edgeType}').to(g.V('{dest}'))" + AddProperty("date", GetCurrentTime());
+    }
+
+    // Returns the source of the selected edge
+    public static string EdgeSourceReference() {
+      return ".outV()";
+    }
+
+    // Returns the edge that joins the current vertex and matches the specified edge type 
+    // and destination
+    public static string GetEdge(string edgeType, string dest) {
+      return $".outE('{edgeType}').where(inV().has('id', '{dest}'))";
+    }
+
+    // Get the outgoing neighbors of the current vertex by specified edge type
+    public static string GetOutNeighbors(string edgeType) {
+      return $".out('{edgeType}')";
+    }
+
+    // Get the incoming neighbors of the current vertex by specified edge type
+    public static string GetInNeighbors(string edgeType) {
+      return $".inE('{edgeType}')";
+    }
+
+    public static string AddProperty(string propertyType, string propertyValue) {
+      return AddProperty(propertyType, propertyValue, true);
+    }
+
+    // Adds a new property to the specified vertex or edge
+    public static string AddProperty(string propertyType, string propertyValue, bool required) {
+      // If the property value is null and required, throw an argument exception
+      if (propertyValue == null) {
+        if (required) {
+          throw new ArgumentException($"Missing PropertyValue {propertyValue}");
+        } else {
+          return "";
+        }
+      }
+
+      return $".property('{propertyType}', '{propertyValue}')";
+    }
+
+    // Require a vertex or edge property type to match a specified input
+    public static string HasProperty(string propertyType, string propertyValue) {
+      return $".has('{propertyType}', '{propertyValue}')";
+    }
+
+    // Require a vertex or edge label type to match a specified input
+    public static string HasLabel(string labelType) {
+      return $".hasLabel('{labelType}')";
+    }
+  }
+}

--- a/brainbeats-backend/QueryBuilder.cs
+++ b/brainbeats-backend/QueryBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using static brainbeats_backend.Utility;
 
 namespace brainbeats_backend {
   public static class QueryBuilder {
@@ -40,7 +41,7 @@ namespace brainbeats_backend {
 
     // Returns the edge that joins the current vertex and matches the specified edge type 
     // and destination
-    public static string GetEdge(string edgeType, string dest) {
+    public static string GetOutEdge(string edgeType, string dest) {
       return $".outE('{edgeType}').where(inV().has('id', '{dest}'))";
     }
 

--- a/brainbeats-backend/QueryStrings.cs
+++ b/brainbeats-backend/QueryStrings.cs
@@ -1,33 +1,13 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Threading.Tasks;
 using static brainbeats_backend.QueryBuilder;
 using static brainbeats_backend.Utility;
 
 namespace brainbeats_backend {
   public class QueryStrings {
-    public static string GetAllOwnedVerticesQuery(string vertexType, string email) {
-      return GetVertex(email) + GetInNeighbors("OWNED_BY") + EdgeSourceReference() + HasLabel(vertexType);
-    }
-    public static string GetAllPrivatelyOwnedVerticesQuery(string vertexType, string email) {
-      return GetAllOwnedVerticesQuery(vertexType, email) + HasProperty("isPrivate", "true");
-    }
-
-    public static string GetAllPublicVerticesQuery(string vertexType) {
-      return GetAllVertices(vertexType) + HasProperty("isPrivate", "false");
-    }
-
-    public static string GetLikedVerticesQuery(string vertexType, string email) {
-      return GetVertex(email) + GetOutNeighbors("LIKES") + HasLabel(vertexType);
-    }
-
-    public static string GetOwnedVerticesQuery(string vertexType, string email) {
-      return GetVertex(email) + GetInNeighbors("OWNED_BY") + EdgeSourceReference() + HasLabel(vertexType);
-    }
-
+    // Creates a new vertex
     public static string CreateVertexQuery(string vertexType, string vertexId, JObject body) {
       HashSet<string> schema = GetSchema(vertexType);
       StringBuilder queryString = new StringBuilder(CreateVertex(vertexType, vertexId));
@@ -44,13 +24,31 @@ namespace brainbeats_backend {
       queryString.Append(AddProperty("createdDate", GetCurrentTime()));
       queryString.Append(AddProperty("modifiedDate", GetCurrentTime()));
 
+      if (body.ContainsKey("seed")) {
+        queryString.Append(AddProperty("seed", body.GetValue("seed").ToString()));
+      }
+
       return queryString.ToString();
     }
 
+    // Creates a new vertex with outgoing edges
+    // Each pair in the edges list has the schema <edge type, destination>
+    public static string CreateVertexQuery(string vertexType, string vertexId, JObject body, List<KeyValuePair<string, string>> edges) {
+      StringBuilder queryString = new StringBuilder(CreateVertexQuery(vertexType, vertexId, body));
+
+      foreach (KeyValuePair<string, string> pair in edges) {
+        queryString.Append(CreateEdge(pair.Key, pair.Value) + EdgeSourceReference());
+      }
+
+      return queryString.ToString();
+    }
+
+    // Returns the specified vertex
     public static string ReadVertexQuery(string vertexId) {
       return GetVertex(vertexId);
     }
 
+    // Updates the specified vertex
     public static string UpdateVertexQuery(string vertexType, string vertexId, JObject body) {
       HashSet<string> schema = GetSchema(vertexType);
       StringBuilder queryString = new StringBuilder(GetVertex(vertexId));
@@ -64,8 +62,42 @@ namespace brainbeats_backend {
       return queryString.ToString();
     }
 
+    // Deletes the specified vertex
     public static string DeleteVertexQuery(string vertexId) {
       return GetVertex(vertexId) + Delete();
+    }
+
+    public static string DeleteOutNeighborQuery(string edgeType, string sourceVertexId, string destVertexId) {
+      return GetVertex(sourceVertexId) + AddProperty("modifiedDate", GetCurrentTime()) + GetOutEdge(edgeType, destVertexId) + Delete();
+    }
+
+    public static string CreateOutNeighborQuery(string edgeType, string sourceVertexId, string destVertexId) {
+      return GetVertex(sourceVertexId) + AddProperty("modifiedDate", GetCurrentTime()) + CreateEdge(edgeType, destVertexId);
+    }
+
+    // Gets all owned vertices of a specific type owned by a given email
+    public static string GetAllOwnedVerticesQuery(string vertexType, string email) {
+      return GetVertex(email) + GetInNeighbors("OWNED_BY") + EdgeSourceReference() + HasLabel(vertexType);
+    }
+
+    // Gets all privately owned vertices of a specific type owned by a given email
+    public static string GetAllPrivateVerticesQuery(string vertexType, string email) {
+      return GetAllOwnedVerticesQuery(vertexType, email) + HasProperty("isPrivate", "true");
+    }
+
+    // Gets all public vertices of a specific type
+    public static string GetAllPublicVerticesQuery(string vertexType) {
+      return GetAllVertices(vertexType) + HasProperty("isPrivate", "false");
+    }
+
+    // Gets neighbors that have an incoming edge coming from the vertexId
+    public static string GetOutNeighborsQuery(string vertexType, string edgeType, string vertexId) {
+      return GetVertex(vertexId) + GetOutNeighbors(edgeType) + HasLabel(vertexType);
+    }
+
+    // Gets neighbors that have an incoming edge directed towards the vertexId
+    public static string GetInNeighborsQuery(string vertexType, string edgeType, string vertexId) {
+      return GetVertex(vertexId) + GetInNeighbors(edgeType) + EdgeSourceReference() + HasLabel(vertexType);
     }
   }
 }

--- a/brainbeats-backend/QueryStrings.cs
+++ b/brainbeats-backend/QueryStrings.cs
@@ -6,7 +6,7 @@ using static brainbeats_backend.QueryBuilder;
 using static brainbeats_backend.Utility;
 
 namespace brainbeats_backend {
-  public class QueryStrings {
+  public static class QueryStrings {
     // Creates a new vertex
     public static string CreateVertexQuery(string vertexType, string vertexId, JObject body) {
       HashSet<string> schema = GetSchema(vertexType);

--- a/brainbeats-backend/QueryStrings.cs
+++ b/brainbeats-backend/QueryStrings.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using static brainbeats_backend.QueryBuilder;
+using static brainbeats_backend.Utility;
+
+namespace brainbeats_backend {
+  public class QueryStrings {
+    public static string GetAllOwnedVerticesQuery(string vertexType, string email) {
+      return GetVertex(email) + GetInNeighbors("OWNED_BY") + EdgeSourceReference() + HasLabel(vertexType);
+    }
+    public static string GetAllPrivatelyOwnedVerticesQuery(string vertexType, string email) {
+      return GetAllOwnedVerticesQuery(vertexType, email) + HasProperty("isPrivate", "true");
+    }
+
+    public static string GetAllPublicVerticesQuery(string vertexType) {
+      return GetAllVertices(vertexType) + HasProperty("isPrivate", "false");
+    }
+
+    public static string GetLikedVerticesQuery(string vertexType, string email) {
+      return GetVertex(email) + GetOutNeighbors("LIKES") + HasLabel(vertexType);
+    }
+
+    public static string GetOwnedVerticesQuery(string vertexType, string email) {
+      return GetVertex(email) + GetInNeighbors("OWNED_BY") + EdgeSourceReference() + HasLabel(vertexType);
+    }
+
+    public static string CreateVertexQuery(string vertexType, string vertexId, JObject body) {
+      HashSet<string> schema = GetSchema(vertexType);
+      StringBuilder queryString = new StringBuilder(CreateVertex(vertexType, vertexId));
+
+      foreach (string field in schema) {
+        // All fields in the schema are required
+        if (body.ContainsKey(field)) {
+          queryString.Append(AddProperty(field, body.GetValue(field).ToString()));
+        } else {
+          throw new ArgumentException();
+        }
+      }
+
+      queryString.Append(AddProperty("createdDate", GetCurrentTime()));
+      queryString.Append(AddProperty("modifiedDate", GetCurrentTime()));
+
+      return queryString.ToString();
+    }
+
+    public static string ReadVertexQuery(string vertexId) {
+      return GetVertex(vertexId);
+    }
+
+    public static string UpdateVertexQuery(string vertexType, string vertexId, JObject body) {
+      HashSet<string> schema = GetSchema(vertexType);
+      StringBuilder queryString = new StringBuilder(GetVertex(vertexId));
+
+      foreach (string field in schema) {
+        if (body.ContainsKey(field)) {
+          queryString.Append(AddProperty(field, body.GetValue(field).ToString()));
+        }
+      }
+
+      return queryString.ToString();
+    }
+
+    public static string DeleteVertexQuery(string vertexId) {
+      return GetVertex(vertexId) + Delete();
+    }
+  }
+}

--- a/brainbeats-backend/Utility.cs
+++ b/brainbeats-backend/Utility.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 
 namespace brainbeats_backend {
-  public class Utility {
+  public static class Utility {
     // Ensures the incoming controller request is of type String
     public static string GetRequest(dynamic req) {
       return req.GetType().Equals(typeof(string)) ? req : req.ToString();
@@ -17,7 +17,9 @@ namespace brainbeats_backend {
     }
 
     public static HashSet<string> GetSchema(string vertexType) {
-      switch (vertexType.ToLower().Trim()) {
+      string type = vertexType.ToLowerInvariant().Trim();
+
+      switch (type) {
         case "user":
           return new HashSet<string> { "firstName", "lastName" };
         case "beat":

--- a/brainbeats-backend/Utility.cs
+++ b/brainbeats-backend/Utility.cs
@@ -10,28 +10,6 @@ namespace brainbeats_backend {
       return req.GetType().Equals(typeof(string)) ? req : req.ToString();
     }
 
-    // Ensures all required fields are supplied in the request body for vertex creation
-    public static bool ValidateCreateRequest(JObject body, HashSet<string> fields) {
-      foreach (string s in fields) {
-        if (!body.ContainsKey(s)) {
-          return false;
-        }
-      }
-
-      return true;
-    }
-
-    // Ensures the only allowed fields are supplied in the request body for vertex modification
-    public static bool ValidateEditRequest(JObject body, HashSet<string> fields) {
-      foreach (KeyValuePair<string, JToken> prop in body) {
-        if (!fields.Contains(prop.Key)) {
-          return false;
-        }
-      }
-
-      return true;
-    }
-
     // Gets the current UNIX time
     public static string GetCurrentTime() {
       int unixTimestamp = (int)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds;

--- a/brainbeats-backend/Utility.cs
+++ b/brainbeats-backend/Utility.cs
@@ -23,7 +23,7 @@ namespace brainbeats_backend {
         case "user":
           return new HashSet<string> { "firstName", "lastName" };
         case "beat":
-          return new HashSet<string> { "name", "duration", "image", "isPrivate", "instrumentList", "attributes", "audio" };
+          return new HashSet<string> { "name", "image", "isPrivate", "instrumentList", "attributes", "audio", "duration" };
         case "sample":
           return new HashSet<string> { "name", "isPrivate", "attributes", "audio" };
         case "playlist":

--- a/brainbeats-backend/Utility.cs
+++ b/brainbeats-backend/Utility.cs
@@ -1,10 +1,35 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
 
 namespace brainbeats_backend {
-  public static class Utility {
+  public class Utility {
     // Ensures the incoming controller request is of type String
     public static string GetRequest(dynamic req) {
       return req.GetType().Equals(typeof(string)) ? req : req.ToString();
+    }
+
+    // Ensures all required fields are supplied in the request body for vertex creation
+    public static bool ValidateCreateRequest(JObject body, HashSet<string> fields) {
+      foreach (string s in fields) {
+        if (!body.ContainsKey(s)) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    // Ensures the only allowed fields are supplied in the request body for vertex modification
+    public static bool ValidateEditRequest(JObject body, HashSet<string> fields) {
+      foreach (KeyValuePair<string, JToken> prop in body) {
+        if (!fields.Contains(prop.Key)) {
+          return false;
+        }
+      }
+
+      return true;
     }
 
     // Gets the current UNIX time
@@ -13,60 +38,26 @@ namespace brainbeats_backend {
       return unixTimestamp.ToString();
     }
 
-    // Creates a new vertex with the partitioning key "type"
-    public static string CreateVertex(string vertexType, string vertexId) {
-      return $"g.addV('{vertexType}')" + 
-        AddProperty("type", vertexType) + 
-        AddProperty("id", vertexId);
-    }
-
-    // Deletes the current vertex or edge
-    public static string Delete() {
-      return $".drop()";
-    }
-
-    // Returns the specified vertex by key
-    public static string GetVertex(string vertexId) {
-      return $"g.V('{vertexId}')";
-    }
-
-    // Creates a new edge and adds the current time as a property
-    public static string CreateEdge(string edgeType, string dest) {
-      return $".addE('{edgeType}').to(g.V('{dest}'))" + AddProperty("date", GetCurrentTime());
-    }
-
-    // Returns the source of the selected edge
-    public static string EdgeSourceReference() {
-      return ".outV()";
-    }
-
-    // Returns the edge that joins the current vertex and matches the specified edge type 
-    // and destination
-    public static string GetEdge(string edgeType, string dest) {
-      return $".outE('{edgeType}').where(inV().has('id', '{dest}'))";
-    }
-
-    // Get the neighbors of the current vertex by specified edge type
-    public static string GetNeighbors(string edgeType) {
-      return $".out('{edgeType}')";
-    }
-
-    public static string AddProperty(string propertyType, string propertyValue) {
-      return AddProperty(propertyType, propertyValue, true);
-    }
-
-    // Adds a new property to the specified vertex or edge
-    public static string AddProperty(string propertyType, string propertyValue, bool required) {
-      // If the property value is null and required, throw an argument exception
-      if (propertyValue == null) {
-        if (required) {
-          throw new ArgumentException($"Missing PropertyValue {propertyValue}");
-        } else {
-          return "";
-        }
+    public static HashSet<string> GetSchema(string vertexType) {
+      switch (vertexType.ToLower().Trim()) {
+        case "user":
+          return new HashSet<string> { "firstName", "lastName" };
+        case "beat":
+          return new HashSet<string> { "name", "email", "duration", "image", "isPrivate", "instrumentList", "attributes", "audio" };
+        case "sample":
+          return new HashSet<string> { "name", "email", "isPrivate", "attributes", "audio" };
+        case "playlist":
+          return new HashSet<string> { "name", "email", "image", "isPrivate" };
+        default:
+          return null;
       }
+    }
 
-      return $".property('{propertyType}', '{propertyValue}')";
+    public static JObject DeserializeRequest(dynamic req) {
+      string request = GetRequest(req);
+      JObject body = JsonConvert.DeserializeObject<dynamic>(request);
+
+      return body;
     }
   }
 }

--- a/brainbeats-backend/Utility.cs
+++ b/brainbeats-backend/Utility.cs
@@ -43,11 +43,11 @@ namespace brainbeats_backend {
         case "user":
           return new HashSet<string> { "firstName", "lastName" };
         case "beat":
-          return new HashSet<string> { "name", "email", "duration", "image", "isPrivate", "instrumentList", "attributes", "audio" };
+          return new HashSet<string> { "name", "duration", "image", "isPrivate", "instrumentList", "attributes", "audio" };
         case "sample":
-          return new HashSet<string> { "name", "email", "isPrivate", "attributes", "audio" };
+          return new HashSet<string> { "name", "isPrivate", "attributes", "audio" };
         case "playlist":
-          return new HashSet<string> { "name", "email", "image", "isPrivate" };
+          return new HashSet<string> { "name", "image", "isPrivate" };
         default:
           return null;
       }


### PR DESCRIPTION
Refactoring:
- QueryStrings.cs consists of wrapper functions to abstract away most queries. API Controllers now call QueryStrings functions instead of constructing queries per-controller.
- QueryBuilder.cs consists of individual query commands utilized in QueryString.cs.
- Utility.cs now consists of generic helper functions not necessarily tied to querying.

Missing APIs:
- Added generic "Like / Unlike" API
- Added querying for all samples, beats, or playlists
- Added generic "Get Owned / Get Liked" API