### PR TITLE
Overarching bugfixes, API improvements & Missing APIs

### DIFF
--- a/brainbeats-backend/AuthConnection.cs
+++ b/brainbeats-backend/AuthConnection.cs
@@ -122,5 +122,22 @@ namespace brainbeats_backend {
 
       return responseString;
     }
+
+    public async Task<string> RefreshToken(string refreshToken) {
+      var values = new Dictionary<string, string>
+      {
+        { "client_id", appId },
+        { "grant_type", "refresh_token" },
+        { "refresh_token", refreshToken },
+        { "scope", $"openid {appId} offline_access" },
+        { "response_type", "token id_token" }
+      };
+
+      var content = new FormUrlEncodedContent(values);
+      var response = await this.httpClient.PostAsync(tokenEndpoint, content);
+      var responseString = await response.Content.ReadAsStringAsync();
+
+      return responseString;
+    }
   }
 }

--- a/brainbeats-backend/AuthConnection.cs
+++ b/brainbeats-backend/AuthConnection.cs
@@ -123,12 +123,12 @@ namespace brainbeats_backend {
       return responseString;
     }
 
-    public async Task<string> RefreshToken(string refreshToken) {
+    public async Task<string> RefreshToken(string token) {
       var values = new Dictionary<string, string>
       {
         { "client_id", appId },
         { "grant_type", "refresh_token" },
-        { "refresh_token", refreshToken },
+        { "refresh_token", token },
         { "scope", $"openid {appId} offline_access" },
         { "response_type", "token id_token" }
       };

--- a/brainbeats-backend/Controllers/BeatController.cs
+++ b/brainbeats-backend/Controllers/BeatController.cs
@@ -42,11 +42,12 @@ namespace brainbeats_backend.Controllers {
       string queryString;
 
       try {
+        string email = request.email.ToLowerInvariant();
         List<KeyValuePair<string, string>> edges = new List<KeyValuePair<string, string>> {
-          new KeyValuePair<string, string>("OWNED_BY", request.email.ToLowerInvariant())
+          new KeyValuePair<string, string>("OWNED_BY", email)
         };
 
-        request.owner = request.email.ToLowerInvariant();
+        request.owner = email;
 
         queryString = await CreateVertexQueryAsync(request, edges);
       } catch (Exception e) {
@@ -78,7 +79,7 @@ namespace brainbeats_backend.Controllers {
 
       // Verify ownership
       try {
-        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("id").ToString().ToLowerInvariant())) {
+        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("id").ToString())) {
           return BadRequest("User is not the owner of this private Beat");
         }
       } catch (Exception e) {
@@ -86,7 +87,7 @@ namespace brainbeats_backend.Controllers {
       }
 
       try {
-        queryString = ReadVertexQuery(body.GetValue("id").ToString().ToLowerInvariant());
+        queryString = ReadVertexQuery(body.GetValue("id").ToString());
       } catch (Exception e) {
         return BadRequest($"Malformed request: {e}");
       }
@@ -273,7 +274,7 @@ namespace brainbeats_backend.Controllers {
 
       // Verify ownership
       try {
-        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("id").ToString().ToLowerInvariant())) {
+        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("id").ToString())) {
           return BadRequest("User is not the owner of this private Beat");
         }
       } catch (Exception e) {
@@ -293,7 +294,7 @@ namespace brainbeats_backend.Controllers {
       }
 
       try {
-        queryString = DeleteVertexQuery(body.GetValue("id").ToString().ToLowerInvariant());
+        queryString = DeleteVertexQuery(body.GetValue("id").ToString());
       } catch (Exception e) {
         return BadRequest($"Malformed request: {e}");
       }

--- a/brainbeats-backend/Controllers/BeatController.cs
+++ b/brainbeats-backend/Controllers/BeatController.cs
@@ -12,6 +12,7 @@ using static brainbeats_backend.Utility;
 namespace brainbeats_backend.Controllers {
   public class Beat {
     public string email { get; set; }
+    public string owner { get; set; }
     public string id { get; set; }
     public string name { get; set; }
     public IFormFile image { get; set; }
@@ -42,8 +43,10 @@ namespace brainbeats_backend.Controllers {
 
       try {
         List<KeyValuePair<string, string>> edges = new List<KeyValuePair<string, string>> {
-          new KeyValuePair<string, string>("OWNED_BY", request.email)
+          new KeyValuePair<string, string>("OWNED_BY", request.email.ToLowerInvariant())
         };
+
+        request.owner = request.email.ToLowerInvariant();
 
         queryString = await CreateVertexQueryAsync(request, edges);
       } catch (Exception e) {
@@ -90,9 +93,7 @@ namespace brainbeats_backend.Controllers {
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        List<dynamic> resultList = await PopulateVertexOwners(result);
-
-        return Ok(resultList);
+        return Ok(result);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -121,9 +122,7 @@ namespace brainbeats_backend.Controllers {
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        List<dynamic> resultList = await PopulateVertexOwners(result);
-
-        return Ok(resultList);
+        return Ok(result);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -152,9 +151,7 @@ namespace brainbeats_backend.Controllers {
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        List<dynamic> resultList = await PopulateVertexOwners(result);
-
-        return Ok(resultList);
+        return Ok(result);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -183,9 +180,7 @@ namespace brainbeats_backend.Controllers {
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        List<dynamic> resultList = await PopulateVertexOwners(result);
-
-        return Ok(resultList);
+        return Ok(result);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -218,10 +213,7 @@ namespace brainbeats_backend.Controllers {
         var resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
         var resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
 
-        List<dynamic> resultListPublic = await PopulateVertexOwners(resultsPublic);
-        List<dynamic> resultListPrivate = await PopulateVertexOwners(resultsPrivate);
-
-        return Ok(resultListPublic.Concat(resultListPrivate));
+        return Ok(resultsPublic.Concat(resultsPrivate));
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }

--- a/brainbeats-backend/Controllers/BeatController.cs
+++ b/brainbeats-backend/Controllers/BeatController.cs
@@ -169,7 +169,7 @@ namespace brainbeats_backend.Controllers {
 
     [HttpPost]
     [Route("update_beat")]
-    public async Task<IActionResult> UpdateBeat(dynamic req) {
+    public async Task<IActionResult> UpdateBeat([FromForm] Beat b) {
       try {
         HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
         AuthConnection.Instance.ValidateToken(authorizationToken);
@@ -179,7 +179,6 @@ namespace brainbeats_backend.Controllers {
         return Unauthorized($"Unauthenticated error: {e}");
       }
 
-      Beat b = DeserializeRequest(req, new Beat());
       string queryString;
 
       // Verify ownership

--- a/brainbeats-backend/Controllers/BeatController.cs
+++ b/brainbeats-backend/Controllers/BeatController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -89,7 +90,9 @@ namespace brainbeats_backend.Controllers {
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        return Ok(result);
+        List<dynamic> resultList = await PopulateVertexOwners(result);
+
+        return Ok(resultList);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -118,7 +121,9 @@ namespace brainbeats_backend.Controllers {
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        return Ok(result);
+        List<dynamic> resultList = await PopulateVertexOwners(result);
+
+        return Ok(resultList);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -147,7 +152,9 @@ namespace brainbeats_backend.Controllers {
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        return Ok(result);
+        List<dynamic> resultList = await PopulateVertexOwners(result);
+
+        return Ok(resultList);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -176,7 +183,9 @@ namespace brainbeats_backend.Controllers {
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        return Ok(result);
+        List<dynamic> resultList = await PopulateVertexOwners(result);
+
+        return Ok(resultList);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -209,17 +218,10 @@ namespace brainbeats_backend.Controllers {
         var resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
         var resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
 
-        List<dynamic> resultList = new List<dynamic>();
+        List<dynamic> resultListPublic = await PopulateVertexOwners(resultsPublic);
+        List<dynamic> resultListPrivate = await PopulateVertexOwners(resultsPrivate);
 
-        foreach (var item in resultsPublic) {
-          resultList.Add(item);
-        }
-
-        foreach (var item in resultsPrivate) {
-          resultList.Add(item);
-        }
-
-        return Ok(resultList);
+        return Ok(resultListPublic.Concat(resultListPrivate));
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }

--- a/brainbeats-backend/Controllers/PlaylistController.cs
+++ b/brainbeats-backend/Controllers/PlaylistController.cs
@@ -48,7 +48,7 @@ namespace brainbeats_backend.Controllers
       }
 
       try {
-        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString().ToLowerInvariant());
         return Ok(result);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
@@ -72,7 +72,7 @@ namespace brainbeats_backend.Controllers
 
       // Verify ownership
       try {
-        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString(), body.GetValue("id").ToString())) {
+        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("id").ToString().ToLowerInvariant())) {
           return BadRequest("User is not the owner of this private Playlist");
         }
       } catch (Exception e) {
@@ -80,7 +80,7 @@ namespace brainbeats_backend.Controllers
       }
 
       try {
-        queryString = ReadVertexQuery(body.GetValue("id").ToString());
+        queryString = ReadVertexQuery(body.GetValue("id").ToString().ToLowerInvariant());
       } catch (Exception e) {
         return BadRequest($"Malformed request: {e}");
       }
@@ -123,6 +123,64 @@ namespace brainbeats_backend.Controllers
     }
 
     [HttpPost]
+    [Route("search_public_playlists")]
+    public async Task<IActionResult> SearchPublicPlaylists(dynamic req) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      JObject body = DeserializeRequest(req);
+      string queryString;
+
+      try {
+        queryString = SearchPublicVertexQuery("playlist", body.GetValue("name").ToString().ToLowerInvariant());
+      } catch (Exception e) {
+        return BadRequest($"Malformed request: {e}");
+      }
+
+      try {
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+        return Ok(result);
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    [HttpPost]
+    [Route("search_owned_playlists")]
+    public async Task<IActionResult> SearchOwnedPlaylists(dynamic req) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      JObject body = DeserializeRequest(req);
+      string queryString;
+
+      try {
+        queryString = SearchOwnedVertexQuery("playlist", body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("name").ToString().ToLowerInvariant());
+      } catch (Exception e) {
+        return BadRequest($"Malformed request: {e}");
+      }
+
+      try {
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+        return Ok(result);
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    [HttpPost]
     [Route("read_playlist_beats")]
     public async Task<IActionResult> ReadPlaylistBeats(dynamic req) {
       try {
@@ -139,7 +197,7 @@ namespace brainbeats_backend.Controllers
 
       // Verify ownership
       try {
-        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString(), body.GetValue("id").ToString())) {
+        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("id").ToString().ToLowerInvariant())) {
           return BadRequest("User is not the owner of this private Playlist");
         }
       } catch (Exception e) {
@@ -147,7 +205,7 @@ namespace brainbeats_backend.Controllers
       }
 
       try {
-        queryString = GetOutNeighborsQuery("beat", "CONTAINS", body.GetValue("id").ToString());
+        queryString = GetOutNeighborsQuery("beat", "CONTAINS", body.GetValue("id").ToString().ToLowerInvariant());
       } catch (Exception e) {
         return BadRequest($"Malformed request: {e}");
       }
@@ -178,7 +236,7 @@ namespace brainbeats_backend.Controllers
 
       try {
         queryStringPublic = GetAllPublicVerticesQuery("playlist");
-        queryStringPrivate = GetAllPrivateVerticesQuery("playlist", body.GetValue("email").ToString());
+        queryStringPrivate = GetAllPrivateVerticesQuery("playlist", body.GetValue("email").ToString().ToLowerInvariant());
       } catch (Exception e) {
         return BadRequest($"Malformed Request: {e}");
       }
@@ -233,7 +291,7 @@ namespace brainbeats_backend.Controllers
       }
 
       try {
-        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString().ToLowerInvariant());
         return Ok(result);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
@@ -257,11 +315,11 @@ namespace brainbeats_backend.Controllers
 
       // Verify ownership
       try {
-        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString(), body.GetValue("playlistId").ToString())) {
+        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("playlistId").ToString().ToLowerInvariant())) {
           return BadRequest("User is not the owner of this private Playlist");
         }
 
-        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString(), body.GetValue("beatId").ToString())) {
+        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("beatId").ToString().ToLowerInvariant())) {
           return BadRequest("User is not the owner of this private Beat");
         }
       } catch (Exception e) {
@@ -269,7 +327,7 @@ namespace brainbeats_backend.Controllers
       }
 
       try {
-        queryString = DeleteOutNeighborQuery("CONTAINS", body.GetValue("playlistId").ToString(), body.GetValue("beatId").ToString());
+        queryString = DeleteOutNeighborQuery("CONTAINS", body.GetValue("playlistId").ToString().ToLowerInvariant(), body.GetValue("beatId").ToString().ToLowerInvariant());
       } catch (Exception e) {
         return BadRequest($"Malformed Request: {e}");
       }
@@ -299,11 +357,11 @@ namespace brainbeats_backend.Controllers
 
       // Verify ownership
       try {
-        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString(), body.GetValue("playlistId").ToString())) {
+        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("playlistId").ToString().ToLowerInvariant())) {
           return BadRequest("User is not the owner of this private Playlist");
         }
 
-        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString(), body.GetValue("beatId").ToString())) {
+        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("beatId").ToString().ToLowerInvariant())) {
           return BadRequest("User is not the owner of this private Beat");
         }
       } catch (Exception e) {
@@ -311,7 +369,7 @@ namespace brainbeats_backend.Controllers
       }
 
       try {
-        queryString = CreateOutNeighborQuery("CONTAINS", body.GetValue("playlistId").ToString(), body.GetValue("beatId").ToString());
+        queryString = CreateOutNeighborQuery("CONTAINS", body.GetValue("playlistId").ToString().ToLowerInvariant(), body.GetValue("beatId").ToString().ToLowerInvariant());
       } catch (Exception e) {
         return BadRequest($"Malformed request: {e}");
       }
@@ -341,7 +399,7 @@ namespace brainbeats_backend.Controllers
 
       // Verify ownership
       try {
-        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString(), body.GetValue("id").ToString())) {
+        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("id").ToString().ToLowerInvariant())) {
           return BadRequest("User is not the owner of this private Playlist");
         }
       } catch (Exception e) {
@@ -349,14 +407,15 @@ namespace brainbeats_backend.Controllers
       }
 
       try {
-        await StorageConnection.Instance.DeleteFileAsync("playlist", body.GetValue("id").ToString() + "_image");
-        await StorageConnection.Instance.DeleteFileAsync("playlist", body.GetValue("id").ToString() + "_audio");
+        // Delete the png or jpg picture associated with this Playlist
+        await StorageConnection.Instance.DeleteFileAsync("user", body.GetValue("email").ToString() + "_image.png");
+        await StorageConnection.Instance.DeleteFileAsync("user", body.GetValue("email").ToString() + "_image.jpg");
       } catch (Exception e) {
         return BadRequest($"Error deleting associated storage uploads for Beat: {e}");
       }
 
       try {
-        queryString = DeleteVertexQuery(body.GetValue("id").ToString());
+        queryString = DeleteVertexQuery(body.GetValue("id").ToString().ToLowerInvariant());
       } catch (Exception e) {
         return BadRequest($"Malformed request: {e}");
       }

--- a/brainbeats-backend/Controllers/PlaylistController.cs
+++ b/brainbeats-backend/Controllers/PlaylistController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -87,7 +88,9 @@ namespace brainbeats_backend.Controllers
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        return Ok(result);
+        List<dynamic> resultList = await PopulateVertexOwners(result);
+
+        return Ok(resultList);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -116,7 +119,9 @@ namespace brainbeats_backend.Controllers
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        return Ok(result);
+        List<dynamic> resultList = await PopulateVertexOwners(result);
+
+        return Ok(resultList);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -145,7 +150,9 @@ namespace brainbeats_backend.Controllers
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        return Ok(result);
+        List<dynamic> resultList = await PopulateVertexOwners(result);
+
+        return Ok(resultList);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -174,7 +181,9 @@ namespace brainbeats_backend.Controllers
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        return Ok(result);
+        List<dynamic> resultList = await PopulateVertexOwners(result);
+
+        return Ok(resultList);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -245,19 +254,12 @@ namespace brainbeats_backend.Controllers
         var resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
         var resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
 
-        List<dynamic> resultList = new List<dynamic>();
+        List<dynamic> resultListPublic = await PopulateVertexOwners(resultsPublic);
+        List<dynamic> resultListPrivate = await PopulateVertexOwners(resultsPrivate);
 
-        foreach (var item in resultsPublic) {
-          resultList.Add(item);
-        }
-
-        foreach (var item in resultsPrivate) {
-          resultList.Add(item);
-        }
-
-        return Ok(resultList);
+        return Ok(resultListPublic.Concat(resultListPrivate));
       } catch (Exception e) {
-        return BadRequest("Something went wrong: {e}");
+        return BadRequest($"Something went wrong: {e}");
       }
     }
 

--- a/brainbeats-backend/Controllers/PlaylistController.cs
+++ b/brainbeats-backend/Controllers/PlaylistController.cs
@@ -13,6 +13,7 @@ namespace brainbeats_backend.Controllers
 {
   public class Playlist {
     public string email { get; set; }
+    public string owner { get; set; }
     public string id { get; set; }
     public string name { get; set; }
     public IFormFile image { get; set; }
@@ -40,8 +41,10 @@ namespace brainbeats_backend.Controllers
 
       try {
         List<KeyValuePair<string, string>> edges = new List<KeyValuePair<string, string>> {
-          new KeyValuePair<string, string>("OWNED_BY", request.email)
+          new KeyValuePair<string, string>("OWNED_BY", request.email.ToLowerInvariant())
         };
+
+        request.owner = request.email.ToLowerInvariant();
 
         queryString = await CreateVertexQueryAsync(request, edges);
       } catch (Exception e) {
@@ -49,7 +52,7 @@ namespace brainbeats_backend.Controllers
       }
 
       try {
-        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString().ToLowerInvariant());
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
         return Ok(result);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
@@ -88,9 +91,7 @@ namespace brainbeats_backend.Controllers
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        List<dynamic> resultList = await PopulateVertexOwners(result);
-
-        return Ok(resultList);
+        return Ok(result);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -119,9 +120,7 @@ namespace brainbeats_backend.Controllers
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        List<dynamic> resultList = await PopulateVertexOwners(result);
-
-        return Ok(resultList);
+        return Ok(result);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -150,9 +149,7 @@ namespace brainbeats_backend.Controllers
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        List<dynamic> resultList = await PopulateVertexOwners(result);
-
-        return Ok(resultList);
+        return Ok(result);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -181,9 +178,7 @@ namespace brainbeats_backend.Controllers
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        List<dynamic> resultList = await PopulateVertexOwners(result);
-
-        return Ok(resultList);
+        return Ok(result);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -253,11 +248,7 @@ namespace brainbeats_backend.Controllers
       try {
         var resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
         var resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
-
-        List<dynamic> resultListPublic = await PopulateVertexOwners(resultsPublic);
-        List<dynamic> resultListPrivate = await PopulateVertexOwners(resultsPrivate);
-
-        return Ok(resultListPublic.Concat(resultListPrivate));
+        return Ok(resultsPublic.Concat(resultsPrivate));
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -293,7 +284,7 @@ namespace brainbeats_backend.Controllers
       }
 
       try {
-        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString().ToLowerInvariant());
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
         return Ok(result);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
@@ -410,10 +401,10 @@ namespace brainbeats_backend.Controllers
 
       try {
         // Delete the png or jpg picture associated with this Playlist
-        await StorageConnection.Instance.DeleteFileAsync("user", body.GetValue("email").ToString() + "_image.png");
-        await StorageConnection.Instance.DeleteFileAsync("user", body.GetValue("email").ToString() + "_image.jpg");
+        await StorageConnection.Instance.DeleteFileAsync("playlist", body.GetValue("id").ToString() + "_image.png");
+        await StorageConnection.Instance.DeleteFileAsync("playlist", body.GetValue("id").ToString() + "_image.jpg");
       } catch (Exception e) {
-        return BadRequest($"Error deleting associated storage uploads for Beat: {e}");
+        return BadRequest($"Error deleting associated storage uploads for Playlist: {e}");
       }
 
       try {

--- a/brainbeats-backend/Controllers/PlaylistController.cs
+++ b/brainbeats-backend/Controllers/PlaylistController.cs
@@ -205,7 +205,7 @@ namespace brainbeats_backend.Controllers
 
     [HttpPost]
     [Route("update_playlist")]
-    public async Task<IActionResult> UpdatePlaylist(dynamic req) {
+    public async Task<IActionResult> UpdatePlaylist([FromForm] Playlist p) {
       try {
         HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
         AuthConnection.Instance.ValidateToken(authorizationToken);
@@ -215,7 +215,6 @@ namespace brainbeats_backend.Controllers
         return Unauthorized($"Unauthenticated error: {e}");
       }
 
-      Playlist p = DeserializeRequest(req, new Playlist());
       string queryString;
 
       // Verify ownership

--- a/brainbeats-backend/Controllers/PlaylistController.cs
+++ b/brainbeats-backend/Controllers/PlaylistController.cs
@@ -40,11 +40,13 @@ namespace brainbeats_backend.Controllers
       string queryString;
 
       try {
+        string email = request.email.ToLowerInvariant();
+
         List<KeyValuePair<string, string>> edges = new List<KeyValuePair<string, string>> {
-          new KeyValuePair<string, string>("OWNED_BY", request.email.ToLowerInvariant())
+          new KeyValuePair<string, string>("OWNED_BY", email)
         };
 
-        request.owner = request.email.ToLowerInvariant();
+        request.owner = email;
 
         queryString = await CreateVertexQueryAsync(request, edges);
       } catch (Exception e) {
@@ -76,7 +78,7 @@ namespace brainbeats_backend.Controllers
 
       // Verify ownership
       try {
-        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("id").ToString().ToLowerInvariant())) {
+        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("id").ToString())) {
           return BadRequest("User is not the owner of this private Playlist");
         }
       } catch (Exception e) {
@@ -84,7 +86,7 @@ namespace brainbeats_backend.Controllers
       }
 
       try {
-        queryString = ReadVertexQuery(body.GetValue("id").ToString().ToLowerInvariant());
+        queryString = ReadVertexQuery(body.GetValue("id").ToString());
       } catch (Exception e) {
         return BadRequest($"Malformed request: {e}");
       }
@@ -201,7 +203,7 @@ namespace brainbeats_backend.Controllers
 
       // Verify ownership
       try {
-        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("id").ToString().ToLowerInvariant())) {
+        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("id").ToString())) {
           return BadRequest("User is not the owner of this private Playlist");
         }
       } catch (Exception e) {
@@ -209,7 +211,7 @@ namespace brainbeats_backend.Controllers
       }
 
       try {
-        queryString = GetOutNeighborsQuery("beat", "CONTAINS", body.GetValue("id").ToString().ToLowerInvariant());
+        queryString = GetOutNeighborsQuery("beat", "CONTAINS", body.GetValue("id").ToString());
       } catch (Exception e) {
         return BadRequest($"Malformed request: {e}");
       }
@@ -308,11 +310,11 @@ namespace brainbeats_backend.Controllers
 
       // Verify ownership
       try {
-        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("playlistId").ToString().ToLowerInvariant())) {
+        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("playlistId").ToString())) {
           return BadRequest("User is not the owner of this private Playlist");
         }
 
-        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("beatId").ToString().ToLowerInvariant())) {
+        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("beatId").ToString())) {
           return BadRequest("User is not the owner of this private Beat");
         }
       } catch (Exception e) {
@@ -320,7 +322,7 @@ namespace brainbeats_backend.Controllers
       }
 
       try {
-        queryString = DeleteOutNeighborQuery("CONTAINS", body.GetValue("playlistId").ToString().ToLowerInvariant(), body.GetValue("beatId").ToString().ToLowerInvariant());
+        queryString = DeleteOutNeighborQuery("CONTAINS", body.GetValue("playlistId").ToString(), body.GetValue("beatId").ToString());
       } catch (Exception e) {
         return BadRequest($"Malformed Request: {e}");
       }
@@ -350,11 +352,11 @@ namespace brainbeats_backend.Controllers
 
       // Verify ownership
       try {
-        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("playlistId").ToString().ToLowerInvariant())) {
+        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("playlistId").ToString())) {
           return BadRequest("User is not the owner of this private Playlist");
         }
 
-        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("beatId").ToString().ToLowerInvariant())) {
+        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("beatId").ToString())) {
           return BadRequest("User is not the owner of this private Beat");
         }
       } catch (Exception e) {
@@ -362,7 +364,7 @@ namespace brainbeats_backend.Controllers
       }
 
       try {
-        queryString = CreateOutNeighborQuery("CONTAINS", body.GetValue("playlistId").ToString().ToLowerInvariant(), body.GetValue("beatId").ToString().ToLowerInvariant());
+        queryString = CreateOutNeighborQuery("CONTAINS", body.GetValue("playlistId").ToString(), body.GetValue("beatId").ToString());
       } catch (Exception e) {
         return BadRequest($"Malformed request: {e}");
       }
@@ -392,7 +394,7 @@ namespace brainbeats_backend.Controllers
 
       // Verify ownership
       try {
-        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("id").ToString().ToLowerInvariant())) {
+        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("id").ToString())) {
           return BadRequest("User is not the owner of this private Playlist");
         }
       } catch (Exception e) {
@@ -408,7 +410,7 @@ namespace brainbeats_backend.Controllers
       }
 
       try {
-        queryString = DeleteVertexQuery(body.GetValue("id").ToString().ToLowerInvariant());
+        queryString = DeleteVertexQuery(body.GetValue("id").ToString());
       } catch (Exception e) {
         return BadRequest($"Malformed request: {e}");
       }

--- a/brainbeats-backend/Controllers/SampleController.cs
+++ b/brainbeats-backend/Controllers/SampleController.cs
@@ -12,6 +12,7 @@ using static brainbeats_backend.Utility;
 namespace brainbeats_backend.Controllers {
   public class Sample {
     public string email { get; set; }
+    public string owner { get; set; }
     public string id { get; set; }
     public string name { get; set; }
     public bool isPrivate { get; set; }
@@ -40,8 +41,10 @@ namespace brainbeats_backend.Controllers {
 
       try {
         List<KeyValuePair<string, string>> edges = new List<KeyValuePair<string, string>> {
-          new KeyValuePair<string, string>("OWNED_BY", request.email)
+          new KeyValuePair<string, string>("OWNED_BY", request.email.ToLowerInvariant())
         };
+
+        request.owner = request.email.ToLowerInvariant();
 
         queryString = await CreateVertexQueryAsync(request, edges);
       } catch (Exception e)  {
@@ -88,9 +91,7 @@ namespace brainbeats_backend.Controllers {
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        List<dynamic> resultList = await PopulateVertexOwners(result);
-
-        return Ok(resultList);
+        return Ok(result);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -119,9 +120,7 @@ namespace brainbeats_backend.Controllers {
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        List<dynamic> resultList = await PopulateVertexOwners(result);
-
-        return Ok(resultList);
+        return Ok(result);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -150,9 +149,7 @@ namespace brainbeats_backend.Controllers {
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        List<dynamic> resultList = await PopulateVertexOwners(result);
-
-        return Ok(resultList);
+        return Ok(result);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -181,9 +178,7 @@ namespace brainbeats_backend.Controllers {
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        List<dynamic> resultList = await PopulateVertexOwners(result);
-
-        return Ok(resultList);
+        return Ok(result);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -215,11 +210,7 @@ namespace brainbeats_backend.Controllers {
       try {
         var resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
         var resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
-
-        List<dynamic> resultListPublic = await PopulateVertexOwners(resultsPublic);
-        List<dynamic> resultListPrivate = await PopulateVertexOwners(resultsPrivate);
-
-        return Ok(resultListPublic.Concat(resultListPrivate));
+        return Ok(resultsPublic.Concat(resultsPrivate));
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }

--- a/brainbeats-backend/Controllers/SampleController.cs
+++ b/brainbeats-backend/Controllers/SampleController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -87,7 +88,9 @@ namespace brainbeats_backend.Controllers {
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        return Ok(result);
+        List<dynamic> resultList = await PopulateVertexOwners(result);
+
+        return Ok(resultList);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -116,7 +119,9 @@ namespace brainbeats_backend.Controllers {
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        return Ok(result);
+        List<dynamic> resultList = await PopulateVertexOwners(result);
+
+        return Ok(resultList);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -145,7 +150,9 @@ namespace brainbeats_backend.Controllers {
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        return Ok(result);
+        List<dynamic> resultList = await PopulateVertexOwners(result);
+
+        return Ok(resultList);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -174,7 +181,9 @@ namespace brainbeats_backend.Controllers {
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        return Ok(result);
+        List<dynamic> resultList = await PopulateVertexOwners(result);
+
+        return Ok(resultList);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -207,17 +216,10 @@ namespace brainbeats_backend.Controllers {
         var resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
         var resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
 
-        List<dynamic> resultList = new List<dynamic>();
+        List<dynamic> resultListPublic = await PopulateVertexOwners(resultsPublic);
+        List<dynamic> resultListPrivate = await PopulateVertexOwners(resultsPrivate);
 
-        foreach (var item in resultsPublic) {
-          resultList.Add(item);
-        }
-
-        foreach (var item in resultsPrivate) {
-          resultList.Add(item);
-        }
-
-        return Ok(resultList);
+        return Ok(resultListPublic.Concat(resultListPrivate));
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }

--- a/brainbeats-backend/Controllers/SampleController.cs
+++ b/brainbeats-backend/Controllers/SampleController.cs
@@ -40,11 +40,13 @@ namespace brainbeats_backend.Controllers {
       string queryString;
 
       try {
+        string email = request.email.ToLowerInvariant();
+
         List<KeyValuePair<string, string>> edges = new List<KeyValuePair<string, string>> {
-          new KeyValuePair<string, string>("OWNED_BY", request.email.ToLowerInvariant())
+          new KeyValuePair<string, string>("OWNED_BY", email)
         };
 
-        request.owner = request.email.ToLowerInvariant();
+        request.owner = email;
 
         queryString = await CreateVertexQueryAsync(request, edges);
       } catch (Exception e)  {
@@ -76,7 +78,7 @@ namespace brainbeats_backend.Controllers {
 
       // Verify ownership
       try {
-        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("id").ToString().ToLowerInvariant())) {
+        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("id").ToString())) {
           return BadRequest("User is not the owner of this private Sample");
         }
       } catch (Exception e) {
@@ -84,7 +86,7 @@ namespace brainbeats_backend.Controllers {
       }
 
       try {
-        queryString = ReadVertexQuery(body.GetValue("id").ToString().ToLowerInvariant());
+        queryString = ReadVertexQuery(body.GetValue("id").ToString());
       } catch (Exception e) {
         return BadRequest($"Malformed request: {e}");
       }
@@ -271,7 +273,7 @@ namespace brainbeats_backend.Controllers {
 
       // Verify ownership
       try {
-        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("id").ToString().ToLowerInvariant())) {
+        if (!await ValidateVertexOwnershipAsync(body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("id").ToString())) {
           return BadRequest("User is not the owner of this private Sample");
         }
       } catch (Exception e) {
@@ -287,7 +289,7 @@ namespace brainbeats_backend.Controllers {
       }
 
       try {
-        queryString = DeleteVertexQuery(body.GetValue("id").ToString().ToLowerInvariant());
+        queryString = DeleteVertexQuery(body.GetValue("id").ToString());
       } catch (Exception e) {
         return BadRequest($"Malformed request: {e}");
       }

--- a/brainbeats-backend/Controllers/SampleController.cs
+++ b/brainbeats-backend/Controllers/SampleController.cs
@@ -16,7 +16,7 @@ namespace brainbeats_backend.Controllers {
     public bool isPrivate { get; set; }
     public string attributes { get; set; }
     public IFormFile audio { get; set; }
-    public IFormFile image { get; set; }
+    public string image { get; set; }
     public string seed { get; set; }
   }
 
@@ -51,7 +51,7 @@ namespace brainbeats_backend.Controllers {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
         return Ok(result);
       } catch (Exception e) {
-        return BadRequest("Something went wrong: {e}");
+        return BadRequest($"Something went wrong: {e}");
       }
     }
 
@@ -80,7 +80,7 @@ namespace brainbeats_backend.Controllers {
       }
 
       try {
-        queryString = ReadVertexQuery(body.GetValue("sampleId").ToString());
+        queryString = ReadVertexQuery(body.GetValue("id").ToString());
       } catch (Exception e) {
         return BadRequest($"Malformed request: {e}");
       }

--- a/brainbeats-backend/Controllers/UserController.cs
+++ b/brainbeats-backend/Controllers/UserController.cs
@@ -75,7 +75,7 @@ namespace brainbeats_backend.Controllers {
           new JProperty("lastName", claimsDictionary["family_name"]),
           new JProperty("email", claimsDictionary["emails"].ToLowerInvariant()));
 
-        IActionResult createUserResult = await CreateUser(user.ToString().ToLowerInvariant()).ConfigureAwait(false);
+        IActionResult createUserResult = await CreateUser(user.ToString()).ConfigureAwait(false);
         OkObjectResult okResult = createUserResult as OkObjectResult;
 
         if (okResult.StatusCode != 200) {

--- a/brainbeats-backend/Controllers/UserController.cs
+++ b/brainbeats-backend/Controllers/UserController.cs
@@ -38,8 +38,8 @@ namespace brainbeats_backend.Controllers {
 
       string res;
       try {
-         res = await AuthConnection.Instance.LoginUser(body.GetValue("email").ToString(), 
-          body.GetValue("password").ToString());
+        res = await AuthConnection.Instance.LoginUser(body.GetValue("email").ToString(),
+         body.GetValue("password").ToString());
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
       }
@@ -87,6 +87,21 @@ namespace brainbeats_backend.Controllers {
       } catch (Exception e) {
         return BadRequest($"Unknown error signing user for the first time: {e}");
       }
+    }
+
+    [HttpPost]
+    [Route("refresh_token")]
+    public async Task<IActionResult> RefreshToken(dynamic req) {
+      JObject body = DeserializeRequest(req);
+
+      string res;
+      try {
+        res = await AuthConnection.Instance.RefreshToken(body.GetValue("refreshToken").ToString());
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+
+      return Ok(res);
     }
 
     // Not a publicly accessible API

--- a/brainbeats-backend/Controllers/UserController.cs
+++ b/brainbeats-backend/Controllers/UserController.cs
@@ -29,7 +29,7 @@ namespace brainbeats_backend.Controllers {
   [Route("api/[controller]")]
   [ApiController]
   public class UserController : ControllerBase {
-    private readonly string defaultProfilePicture = "DEFAULT_PROFILE_PLACEHOLDER";
+    private readonly string defaultProfilePicture = $"{StorageConnection.Instance.StorageEndpoint}/static/profile_picture.png";
 
     [HttpPost]
     [Route("login_user")]

--- a/brainbeats-backend/Controllers/UserController.cs
+++ b/brainbeats-backend/Controllers/UserController.cs
@@ -233,10 +233,10 @@ namespace brainbeats_backend.Controllers {
       string queryString;
 
       try {
-        string extension = Path.GetExtension(request.image.FileName);
+        string extension = Path.GetExtension(request.image.FileName).ToLowerInvariant();
 
         // Reject improper file extensions
-        if (!extension.ToLowerInvariant().Equals(".jpg") && !extension.ToLowerInvariant().Equals(".png")) {
+        if (!extension.Equals(".jpg") && !extension.Equals(".png")) {
           return BadRequest("Image file extension must be jpg or png");
         }
 
@@ -568,7 +568,7 @@ namespace brainbeats_backend.Controllers {
       string queryString;
 
       try {
-        queryString = CreateOutNeighborQuery("LIKES", body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("vertexId").ToString().ToLowerInvariant());
+        queryString = CreateOutNeighborQuery("LIKES", body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("vertexId").ToString());
       } catch (Exception e) {
         return BadRequest($"Malformed request: {e}");
       }
@@ -597,7 +597,7 @@ namespace brainbeats_backend.Controllers {
       string queryString;
 
       try {
-        queryString = DeleteOutNeighborQuery("LIKES", body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("vertexId").ToString().ToLowerInvariant());
+        queryString = DeleteOutNeighborQuery("LIKES", body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("vertexId").ToString());
       } catch (Exception e) {
         return BadRequest($"Malformed request: {e}");
       }
@@ -618,7 +618,7 @@ namespace brainbeats_backend.Controllers {
       string queryString;
 
       try {
-        queryString = GetOutNeighborsQuery("user", "OWNED_BY", body.GetValue("vertexId").ToString().ToLowerInvariant());
+        queryString = GetOutNeighborsQuery("user", "OWNED_BY", body.GetValue("vertexId").ToString());
       } catch (Exception e) {
         return BadRequest($"Malformed request: {e}");
       }
@@ -647,7 +647,7 @@ namespace brainbeats_backend.Controllers {
       string queryString;
 
       try {
-        queryString = CreateOutNeighborQuery("RECOMMENDED", body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("vertexId").ToString().ToLowerInvariant());
+        queryString = CreateOutNeighborQuery("RECOMMENDED", body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("vertexId").ToString());
       } catch (Exception e) {
         return BadRequest($"Malformed request: {e}");
       }

--- a/brainbeats-backend/Controllers/UserController.cs
+++ b/brainbeats-backend/Controllers/UserController.cs
@@ -127,7 +127,7 @@ namespace brainbeats_backend.Controllers {
     }
 
     [HttpPost]
-    [Route("read_user")]
+    [Route("read_user")] 
     public async Task<IActionResult> ReadUser(dynamic req) {
       try {
         HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
@@ -277,6 +277,35 @@ namespace brainbeats_backend.Controllers {
 
       try {
         var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+        return Ok(result);
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    [HttpGet]
+    [Route("get_all_users")]
+    public async Task<IActionResult> GetAllUsers() {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      string queryString;
+
+      try {
+        queryString = GetAllVerticesQuery("user");
+      } catch (Exception e) {
+        return BadRequest($"Malformed Request: {e}");
+      }
+
+      try {
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+
         return Ok(result);
       } catch (Exception e) {
         return BadRequest($"Something went wrong: {e}");
@@ -590,6 +619,35 @@ namespace brainbeats_backend.Controllers {
 
       try {
         queryString = GetOutNeighborsQuery("user", "OWNED_BY", body.GetValue("vertexId").ToString().ToLowerInvariant());
+      } catch (Exception e) {
+        return BadRequest($"Malformed request: {e}");
+      }
+
+      try {
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+        return Ok(result);
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    [HttpPost]
+    [Route("recommend_vertex")]
+    public async Task<IActionResult> RecommendVertex(dynamic req) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      JObject body = DeserializeRequest(req);
+      string queryString;
+
+      try {
+        queryString = CreateOutNeighborQuery("RECOMMENDED", body.GetValue("email").ToString().ToLowerInvariant(), body.GetValue("vertexId").ToString().ToLowerInvariant());
       } catch (Exception e) {
         return BadRequest($"Malformed request: {e}");
       }

--- a/brainbeats-backend/QueryStrings.cs
+++ b/brainbeats-backend/QueryStrings.cs
@@ -53,33 +53,7 @@ namespace brainbeats_backend {
           throw new ArgumentException($"{prop.Name} field is missing");
         }
 
-        Type type = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
-        if (type == typeof(IFormFile)) {
-          IFormFile file = (IFormFile) prop.GetValue(obj);
-          string extension = Path.GetExtension(file.FileName);
-
-          // Reject improper file extensions
-          if (prop.Name.Equals("audio") && (!extension.ToLowerInvariant().Equals(".wav") && !extension.ToLowerInvariant().Equals(".mp3"))) {
-            throw new ArgumentException($"{prop.Name} file extension must be wav or mp3");
-          }
-
-          if (prop.Name.Equals("image") && (!extension.ToLowerInvariant().Equals(".jpg") && !extension.ToLowerInvariant().Equals(".png"))) {
-            throw new ArgumentException($"{prop.Name} file extension must be jpg or png");
-          }
-
-          string fileName = $"{vertexId}_{prop.Name}";
-
-          string url = await StorageConnection.Instance.UploadFileAsync(file, vertexType, fileName);
-          queryString.Append(AddProperty(prop.Name, url));
-        } else {
-          string value = prop.GetValue(obj).ToString();
-          queryString.Append(AddProperty(prop.Name, value));
-
-          // If this is the "name" field, make a lowercased field for type insensitive searches
-          if (prop.Name.Equals("name")) {
-            queryString.Append(AddProperty("searchName", value.ToLowerInvariant()));
-          }
-        }
+        queryString.Append(await SetField(prop, vertexType, vertexId, obj));
       }
 
       // Append the seed field if it is present
@@ -126,36 +100,50 @@ namespace brainbeats_backend {
           continue;
         }
 
-        Type type = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
-        if (type == typeof(IFormFile)) {
-          IFormFile file = (IFormFile) prop.GetValue(obj);
-          string extension = Path.GetExtension(file.FileName);
-
-          // Reject improper file extensions
-          if (prop.Name.Equals("audio") && (!extension.ToLowerInvariant().Equals(".wav") && !extension.ToLowerInvariant().Equals(".mp3"))) {
-            throw new ArgumentException($"{prop.Name} file extension must be wav or mp3");
-          }
-
-          if (prop.Name.Equals("image") && (!extension.ToLowerInvariant().Equals(".jpg") && !extension.ToLowerInvariant().Equals(".png"))) {
-            throw new ArgumentException($"{prop.Name} file extension must be jpg or png");
-          }
-
-          string fileName = $"{vertexId}_{prop.Name}";
-
-          string url = await StorageConnection.Instance.UploadFileAsync(file, vertexType, fileName);
-          queryString.Append(AddProperty(prop.Name, url));
-        } else {
-          string value = prop.GetValue(obj).ToString();
-          queryString.Append(AddProperty(prop.Name, value));
-
-          // If this is the "name" field, make a lowercased field for type insensitive searches
-          if (prop.Name.Equals("name")) {
-            queryString.Append(AddProperty("searchName", value.ToLowerInvariant()));
-          }
-        }
+        queryString.Append(await SetField(prop, vertexType, vertexId, obj));
       }
 
       queryString.Append(AddProperty("modifiedDate", GetCurrentTime()));
+
+      return queryString.ToString();
+    }
+
+    // Helper method to add a vertex property based on a specific prop
+    private static async Task<string> SetField(PropertyInfo prop, string vertexType, string vertexId, object obj) {
+      StringBuilder queryString = new StringBuilder();
+      Type type = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
+
+      if (type == typeof(IFormFile)) {
+        IFormFile file = (IFormFile)prop.GetValue(obj);
+        string extension = Path.GetExtension(file.FileName).ToLowerInvariant();
+
+        // Reject improper file extensions
+        if (prop.Name.Equals("audio") && (!extension.Equals(".wav") && !extension.Equals(".mp3"))) {
+          throw new ArgumentException($"{prop.Name} file extension must be wav or mp3");
+        }
+
+        if (prop.Name.Equals("image") && (!extension.Equals(".jpg") && !extension.Equals(".png"))) {
+          throw new ArgumentException($"{prop.Name} file extension must be jpg or png");
+        }
+
+        string fileName = $"{vertexId}_{prop.Name}{extension}";
+
+        string url = await StorageConnection.Instance.UploadFileAsync(file, vertexType, fileName);
+        queryString.Append(AddProperty(prop.Name, url));
+      } else {
+        string value = prop.GetValue(obj).ToString();
+
+        if (prop.Name.Equals("image")) {
+          value = $"{StorageConnection.Instance.StorageEndpoint}/static/{value}.png";
+        }
+
+        queryString.Append(AddProperty(prop.Name, value));
+
+        // If this is the "name" field, make a lowercased field for type insensitive searches
+        if (prop.Name.Equals("name")) {
+          queryString.Append(AddProperty("searchName", value.ToLowerInvariant()));
+        }
+      }
 
       return queryString.ToString();
     }
@@ -196,12 +184,12 @@ namespace brainbeats_backend {
 
     // Gets all privately owned vertices of a specific type owned by a given email
     public static string GetAllPrivateVerticesQuery(string vertexType, string email) {
-      return GetAllOwnedVerticesQuery(vertexType, email) + HasProperty("isPrivate", "true");
+      return GetAllOwnedVerticesQuery(vertexType, email) + HasProperty("isPrivate", "True");
     }
 
     // Gets all public vertices of a specific type
     public static string GetAllPublicVerticesQuery(string vertexType) {
-      return GetAllVertices(vertexType) + HasProperty("isPrivate", "false");
+      return GetAllVertices(vertexType) + HasProperty("isPrivate", "False");
     }
 
     // Gets neighbors that have an incoming edge coming from the vertexId

--- a/brainbeats-backend/QueryStrings.cs
+++ b/brainbeats-backend/QueryStrings.cs
@@ -53,7 +53,7 @@ namespace brainbeats_backend {
           throw new ArgumentException($"{prop.Name} field is missing");
         }
 
-        queryString.Append(await SetField(prop, vertexType, vertexId, obj));
+        queryString.Append(await SetField(prop, vertexType, vertexId, obj).ConfigureAwait(false));
       }
 
       // Append the seed field if it is present
@@ -100,7 +100,7 @@ namespace brainbeats_backend {
           continue;
         }
 
-        queryString.Append(await SetField(prop, vertexType, vertexId, obj));
+        queryString.Append(await SetField(prop, vertexType, vertexId, obj).ConfigureAwait(false));
       }
 
       queryString.Append(AddProperty("modifiedDate", GetCurrentTime()));

--- a/brainbeats-backend/QueryStrings.cs
+++ b/brainbeats-backend/QueryStrings.cs
@@ -162,6 +162,16 @@ namespace brainbeats_backend {
       return GetAllVertices(vertexType) + HasProperty("searchName", searchWord);
     }
 
+    // Searches the specified public vertex
+    public static string SearchPublicVertexQuery(string vertexType, string searchWord) {
+      return GetAllPublicVerticesQuery(vertexType) + HasProperty("searchName", searchWord);
+    }
+
+    // Searches the specified owned vertex
+    public static string SearchOwnedVertexQuery(string vertexType, string email, string searchWord) {
+      return GetAllOwnedVerticesQuery(vertexType, email) + HasProperty("searchName", searchWord);
+    }
+
     // Deletes the specified vertex
     public static string DeleteVertexQuery(string vertexId) {
       return GetVertex(vertexId) + Delete();

--- a/brainbeats-backend/QueryStrings.cs
+++ b/brainbeats-backend/QueryStrings.cs
@@ -197,6 +197,10 @@ namespace brainbeats_backend {
       return GetAllOwnedVerticesQuery(vertexType, email) + HasProperty("isPrivate", "True");
     }
 
+    public static string GetAllVerticesQuery(string vertexType) {
+      return GetAllVertices(vertexType);
+    }
+
     // Gets all public vertices of a specific type
     public static string GetAllPublicVerticesQuery(string vertexType) {
       return GetAllVertices(vertexType) + HasProperty("isPrivate", "False");

--- a/brainbeats-backend/Startup.cs
+++ b/brainbeats-backend/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -33,6 +34,11 @@ namespace brainbeats_backend {
           .AllowCredentials()
           .Build();
         });
+      });
+
+      services.Configure<KestrelServerOptions>(options =>
+      {
+        options.Limits.MaxRequestBodySize = 52428800; // Bytes; maximum size of a request is 50MB
       });
 
       services.AddControllers();

--- a/brainbeats-backend/StorageConnection.cs
+++ b/brainbeats-backend/StorageConnection.cs
@@ -13,23 +13,25 @@ namespace brainbeats_backend {
   public class StorageConnection {
     public static StorageConnection Instance { get; set; }
 
-    private BlobServiceClient blobServiceClient { get; set; }
+    private BlobServiceClient BlobServiceClient { get; set; }
+    public string StorageEndpoint { get; set; }
 
     public static void Init(IConfiguration configuration) {
       Instance = new StorageConnection(configuration);
     }
 
     private StorageConnection(IConfiguration configuration) {
-      blobServiceClient = new BlobServiceClient(configuration["Storage:ConnectionString"]);
+      BlobServiceClient = new BlobServiceClient(configuration["Storage:ConnectionString"]);
+      StorageEndpoint = configuration["Storage:StorageEndpoint"];
     }
 
     public async Task<string> UploadFileAsync(IFormFile file, string containerName, string fileName) {
       BlobContainerClient containerClient;
 
       try {
-        containerClient = await blobServiceClient.CreateBlobContainerAsync(containerName);
+        containerClient = await BlobServiceClient.CreateBlobContainerAsync(containerName);
       } catch {
-        containerClient = blobServiceClient.GetBlobContainerClient(containerName);
+        containerClient = BlobServiceClient.GetBlobContainerClient(containerName);
       }
 
       BlobClient blobClient = containerClient.GetBlobClient(fileName);
@@ -49,9 +51,9 @@ namespace brainbeats_backend {
       BlobContainerClient containerClient;
 
       try {
-        containerClient = await blobServiceClient.CreateBlobContainerAsync(containerName);
+        containerClient = await BlobServiceClient.CreateBlobContainerAsync(containerName);
       } catch {
-        containerClient = blobServiceClient.GetBlobContainerClient(containerName);
+        containerClient = BlobServiceClient.GetBlobContainerClient(containerName);
       }
 
       BlobClient blobClient = containerClient.GetBlobClient(fileName);

--- a/brainbeats-backend/Utility.cs
+++ b/brainbeats-backend/Utility.cs
@@ -41,6 +41,24 @@ namespace brainbeats_backend {
       return true;
     }
 
+    public static async Task<List<dynamic>> PopulateVertexOwners(Gremlin.Net.Driver.ResultSet<dynamic> vertices) {
+      List<dynamic> resultList = new List<dynamic>();
+
+      foreach (var searchVertex in vertices) {
+        string queryString = GetOutNeighborsQuery("user", "OWNED_BY", searchVertex["id"].ToString().ToLowerInvariant());
+        var owners = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+
+        foreach (var ownerVertex in owners) {
+          searchVertex["owner"] = ownerVertex["id"];
+          resultList.Add(searchVertex);
+
+          break;
+        }
+      }
+
+      return resultList;
+    }
+
     // Gets the current UNIX time
     public static string GetCurrentTime() {
       int unixTimestamp = (int)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds;


### PR DESCRIPTION
- Delete Vertex  APIs now deletes the corresponding files uploaded to storage
- Missing Refresh Token API implemented
- Search APIs expanded to explicitly search public / owned Vertices
- Create Vertex Requests formatted w.r.t Plain C# Objects
- Vertex Ownership now a part of the Vertex itself
- Vertex Ownership validated before allowing Vertex Update or Deletions
- Relevant fields in requests forced to lowercase before processing
- Samples image field is now a string