### PR TITLE
Backend Refactor & API v2.0

### DIFF
--- a/brainbeats-backend/AuthConnection.cs
+++ b/brainbeats-backend/AuthConnection.cs
@@ -52,9 +52,19 @@ namespace brainbeats_backend {
       httpClient = new HttpClient();
     }
 
-    public JwtSecurityToken DecodeToken(string token) {
+    public static JwtSecurityToken DecodeToken(string token) {
       var handler = new JwtSecurityTokenHandler();
       return handler.ReadJwtToken(token);
+    }
+
+    public static Dictionary<string, string> GetClaimsFromToken(JwtSecurityToken jwt) {
+      Dictionary<string, string> claimsDictionary = new Dictionary<string, string>();
+
+      foreach (Claim claim in jwt.Claims) {
+        claimsDictionary[claim.Type] = claim.Value;
+      }
+
+      return claimsDictionary;
     }
 
     public JwtSecurityToken ValidateToken(string token) {

--- a/brainbeats-backend/Controllers/AuthController.cs
+++ b/brainbeats-backend/Controllers/AuthController.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json.Linq;
+using static brainbeats_backend.Utility;
+using static brainbeats_backend.QueryBuilder;
+
+namespace brainbeats_backend.Controllers {
+  [Route("api/v2")]
+  [ApiController]
+  public class AuthController : ControllerBase {
+    [HttpPost]
+    [Route("login")]
+    public async Task<IActionResult> Login(dynamic req) {
+      JObject body = DeserializeRequest(req);
+
+      if (!body.ContainsKey("email") || !body.ContainsKey("password")) {
+        return BadRequest("Request body must contain 'email' and 'password'");
+      }
+
+      string res;
+      try {
+        res = await AuthConnection.Instance.LoginUser(body.GetValue("email").ToString().ToLowerInvariant(),
+          body.GetValue("password").ToString());
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+
+      // If the user exists in Azure B2C but doesn't exist in the database, create the user's profile
+      // First, get the user's claims from the generated JWT
+      JObject tokenObject = DeserializeRequest(res);
+
+      if (tokenObject.ContainsKey("error")) {
+        return Unauthorized(tokenObject.GetValue("error_description").ToString());
+      }
+
+      JwtSecurityToken jwt = AuthConnection.DecodeToken(tokenObject.GetValue("access_token").ToString());
+      Dictionary<string, string> claimsDictionary = AuthConnection.GetClaimsFromToken(jwt);
+
+      try {
+        // See if the user exists in the database
+        string queryString = GetVertex(claimsDictionary["emails"]);
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+
+        // If the user exists, return Ok()
+        if (result.Count > 0) {
+          return Ok(res);
+        }
+
+        string firstName = claimsDictionary["given_name"];
+        string lastName = claimsDictionary["family_name"];
+        string email = claimsDictionary["emails"].ToLowerInvariant();
+
+        // Else, create the user
+        UserVertex u = new UserVertex(firstName, lastName);
+
+        IActionResult createUserResult = await new UsersController().CreateUser(email, u).ConfigureAwait(false);
+        OkObjectResult okResult = createUserResult as OkObjectResult;
+
+        if (okResult.StatusCode != 200) {
+          return BadRequest("Error creating new user vertex when signing in user for the first time");
+        }
+
+        return Ok(res);
+
+      } catch (Exception e) {
+        return BadRequest($"Unknown error signing user for the first time: {e}");
+      }
+    }
+
+    [HttpPost]
+    [Route("refresh_token")]
+    public async Task<IActionResult> RefreshToken(dynamic req) {
+      JObject body = DeserializeRequest(req);
+
+      if (!body.ContainsKey("refreshToken")) {
+        return BadRequest("Request body must contain 'refreshToken'");
+      }
+
+      string res;
+      try {
+        res = await AuthConnection.Instance.RefreshToken(body.GetValue("refreshToken").ToString());
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+
+      return Ok(res);
+    }
+  }
+}

--- a/brainbeats-backend/Controllers/BeatsController.cs
+++ b/brainbeats-backend/Controllers/BeatsController.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Threading.Tasks;
+using Gremlin.Net.Driver.Exceptions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
+using static brainbeats_backend.GremlinQueries.BeatQueries;
+
+namespace brainbeats_backend.Controllers {
+  public class BeatVertex {
+    public string name { get; set; }
+    public IFormFile image { get; set; }
+    public bool isPrivate { get; set; }
+    public string instrumentList { get; set; }
+    public IFormFile audio { get; set; }
+    public string attributes { get; set; }
+    public int duration { get; set; }
+  }
+
+  [Route("api/v2/beats")]
+  [ApiController]
+  public class BeatsController : ControllerBase {
+    // GET api/v2/beats/{beatId}
+    [HttpGet("{beatId}")]
+    public async Task<IActionResult> ReadBeat(string beatId) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      try {
+        var result = await ReadBeatVertexQuery(beatId);
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    // GET api/v2/beats?name=name&email=email
+    [HttpGet("")]
+    public async Task<IActionResult> GetBeats(string name, string email) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+      
+      try {
+        var result = await SearchBeatVertexQuery(name, email);
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    // POST api/v2/beats/create/{email}?seed=seed
+    [HttpPost("create/{email}")]
+    public async Task<IActionResult> CreateBeat(string email, string seed, [FromForm] BeatVertex b) {
+      try {
+        //HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        //AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      try {
+        var result = await CreateBeatVertexQuery(email, b, seed);
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    // PUT api/v2/beats/update/{beatId}
+    [HttpPut("update/{beatId}")]
+    public async Task<IActionResult> UpdateBeat(string beatId, [FromForm] BeatVertex b) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      try {
+        var result = await UpdateBeatVertexQuery(beatId, b);
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    // DELETE api/v2/beats/delete/{beatId}
+    [HttpDelete("delete/{beatId}")]
+    public async Task<IActionResult> DeleteBeat(string beatId) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      try {
+        var result = await DeleteBeatVertexQuery(beatId);
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+  }
+}

--- a/brainbeats-backend/Controllers/BeatsController.cs
+++ b/brainbeats-backend/Controllers/BeatsController.cs
@@ -72,8 +72,8 @@ namespace brainbeats_backend.Controllers {
     [HttpPost("create/{email}")]
     public async Task<IActionResult> CreateBeat(string email, string seed, [FromForm] BeatVertex b) {
       try {
-        //HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
-        //AuthConnection.Instance.ValidateToken(authorizationToken);
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
       } catch (ArgumentException e) {
         return BadRequest($"Malformed or missing authorization token: {e}");
       } catch (Exception e) {

--- a/brainbeats-backend/Controllers/PlaylistsController.cs
+++ b/brainbeats-backend/Controllers/PlaylistsController.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Threading.Tasks;
+using Gremlin.Net.Driver.Exceptions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
+using Newtonsoft.Json.Linq;
+using static brainbeats_backend.GremlinQueries.PlaylistQueries;
+using static brainbeats_backend.Utility;
+
+namespace brainbeats_backend.Controllers {
+  public class PlaylistVertex {
+    public string name { get; set; }
+    public IFormFile image { get; set; }
+    public bool isPrivate { get; set; }
+  }
+
+  [Route("api/v2/playlists")]
+  [ApiController]
+  public class PlaylistsController : ControllerBase {
+    // GET api/v2/playlists/{playlistId}
+    [HttpGet("{playlistId}")]
+    public async Task<IActionResult> ReadPlaylist(string playlistId) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      try {
+        var result = await ReadPlaylistVertexQuery(playlistId);
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    // GET api/v2/playlists?name=name&email=email
+    [HttpGet("")]
+    public async Task<IActionResult> GetPlaylists(string name, string email) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      try {
+        var result = await SearchPlaylistVertexQuery(name, email);
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    // POST api/v2/playlists/create/{email}?seed=seed
+    [HttpPost("create/{email}")]
+    public async Task<IActionResult> CreatePlaylist(string email, string seed, [FromForm] PlaylistVertex p) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      try {
+        var result = await CreatePlaylistVertexQuery(email, p, seed);
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    // PUT api/v2/playlists/add_beats/{playlistId}
+    [HttpPut("add_beats/{playlistId}")]
+    public async Task<IActionResult> UpdatePlaylistAddBeats(string playlistId, dynamic req) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      try {
+        JObject body = DeserializeRequest(req);
+
+        if (!body.ContainsKey("beatId")) {
+          return BadRequest("Request body must contain 'beatId'");
+        }
+
+        var result = await UpdatePlaylistAddBeat(playlistId, body.GetValue("beatId").ToString());
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    // PUT api/v2/playlists/remove_beats/{playlistId}
+    [HttpPut("remove_beats/{playlistId}")]
+    public async Task<IActionResult> UpdatePlaylistRemoveBeats(string playlistId, dynamic req) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      try {
+        JObject body = DeserializeRequest(req);
+
+        if (!body.ContainsKey("beatId")) {
+          return BadRequest("Request body must contain 'beatId'");
+        }
+
+        var result = await UpdatePlaylistRemoveBeat(playlistId, body.GetValue("beatId").ToString());
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    // PUT api/v2/playlists/update/{playlistId}
+    [HttpPut("update/{playlistId}")]
+    public async Task<IActionResult> UpdatePlaylist(string playlistId, [FromForm] PlaylistVertex p) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      try {
+        var result = await UpdatePlaylistVertexQuery(playlistId, p);
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    // DELETE api/v2/playlists/delete/{playlistId}
+    [HttpDelete("delete/{playlistId}")]
+    public async Task<IActionResult> DeletePlaylist(string playlistId) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      try {
+        var result = await DeletePlaylistVertexQuery(playlistId);
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+  }
+}
+

--- a/brainbeats-backend/Controllers/SamplesController.cs
+++ b/brainbeats-backend/Controllers/SamplesController.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Threading.Tasks;
+using Gremlin.Net.Driver.Exceptions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
+using static brainbeats_backend.GremlinQueries.SampleQueries;
+
+namespace brainbeats_backend.Controllers {
+  public class SampleVertex {
+    public string name { get; set; }
+    public bool isPrivate { get; set; }
+    public string attributes { get; set; }
+    public IFormFile audio { get; set; }
+    public string image { get; set; }
+  }
+
+  [Route("api/v2/samples")]
+  [ApiController]
+  public class SamplesController : ControllerBase {
+    // GET api/v2/samples/{sampleId}
+    [HttpGet("{sampleId}")]
+    public async Task<IActionResult> ReadSample(string sampleId) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      try {
+        var result = await ReadSampleVertexQuery(sampleId);
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    // GET api/v2/samples?name=name&email=email
+    [HttpGet("")]
+    public async Task<IActionResult> GetSamples(string name, string email) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      try {
+        var result = await SearchSampleVertexQuery(name, email);
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    // POST api/v2/samples/create/{email}?seed=seed
+    [HttpPost("create/{email}")]
+    public async Task<IActionResult> CreateSample(string email, string seed, [FromForm] SampleVertex p) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      try {
+        var result = await CreateSampleVertexQuery(email, p, seed);
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    // PUT api/v2/samples/update/{sampleId}
+    [HttpPut("update/{sampleId}")]
+    public async Task<IActionResult> UpdateSample(string sampleId, [FromForm] SampleVertex p) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      try {
+        var result = await UpdateSampleVertexQuery(sampleId, p);
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    // DELETE api/v2/samples/delete/{sampleId}
+    [HttpDelete("delete/{sampleId}")]
+    public async Task<IActionResult> DeleteSample(string sampleId) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      try {
+        var result = await DeleteSampleVertexQuery(sampleId);
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+  }
+}

--- a/brainbeats-backend/Controllers/UserController.cs
+++ b/brainbeats-backend/Controllers/UserController.cs
@@ -52,7 +52,7 @@ namespace brainbeats_backend.Controllers {
         return Unauthorized(tokenObject.GetValue("error_description").ToString());
       }
 
-      JwtSecurityToken jwt = AuthConnection.Instance.DecodeToken(tokenObject.GetValue("access_token").ToString());
+      JwtSecurityToken jwt = AuthConnection.DecodeToken(tokenObject.GetValue("access_token").ToString());
 
       Dictionary<string, string> claimsDictionary = new Dictionary<string, string>();
       foreach (Claim claim in jwt.Claims) {

--- a/brainbeats-backend/Controllers/UsersController.cs
+++ b/brainbeats-backend/Controllers/UsersController.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Threading.Tasks;
+using Gremlin.Net.Driver;
+using Gremlin.Net.Driver.Exceptions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
+using static brainbeats_backend.GremlinQueries.UserQueries;
+
+namespace brainbeats_backend.Controllers {
+  public class UserVertex {
+    public string firstName { get; set; }
+    public string lastName { get; set; }
+    public IFormFile image { get; set; }
+
+    public UserVertex(string firstName, string lastName) {
+      this.firstName = firstName;
+      this.lastName = lastName;
+    }
+  }
+
+  [Route("api/v2/users")]
+  [ApiController]
+  public class UsersController : ControllerBase {
+    // GET api/v2/users/{email}
+    [HttpGet("{email}")]
+    public async Task<IActionResult> ReadUser(string email) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      email = email.ToLowerInvariant();
+
+      try {
+        ResultSet<dynamic> result = await ReadUserVertexQuery(email);
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    // GET api/v2/users/{email}/{relationship}?type=type
+    [HttpGet("{email}/{relationship}")]
+    public async Task<IActionResult> ReadUserNeighbors(string email, string relationship, string type) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      email = email.ToLowerInvariant();
+
+      try {
+        return Ok(await GetUserVertexNeighborsQuery(email, relationship, type));
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    // Internal use only
+    public async Task<IActionResult> CreateUser(string email, UserVertex u) {
+      try {
+        var result = await CreateUserVertexQuery(email, u);
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    // PUT api/v2/users/update/{email}
+    [HttpPut("update/{email}")]
+    public async Task<IActionResult> UpdateUser(string email, UserVertex u) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      try {
+        var result = await UpdateUserVertexQuery(email, u);
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+
+    // DELETE api/v2/users/delete/{email}
+    [HttpDelete("delete/{email}")]
+    public async Task<IActionResult> DeleteUser(string email) {
+      try {
+        HttpContext.Request.Headers.TryGetValue("Authorization", out StringValues authorizationToken);
+        AuthConnection.Instance.ValidateToken(authorizationToken);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed or missing authorization token: {e}");
+      } catch (Exception e) {
+        return Unauthorized($"Unauthenticated error: {e}");
+      }
+
+      try {
+        var result = await DeleteUserVertexQuery(email);
+        return Ok(result);
+      } catch (ArgumentException e) {
+        return BadRequest($"Malformed request: {e}");
+      } catch (ResponseException e) {
+        return BadRequest($"Error with Gremlin Query: {e}");
+      } catch (Exception e) {
+        return BadRequest($"Something went wrong: {e}");
+      }
+    }
+  }
+}

--- a/brainbeats-backend/GremlinQueries/BeatQueries.cs
+++ b/brainbeats-backend/GremlinQueries/BeatQueries.cs
@@ -12,143 +12,115 @@ using static brainbeats_backend.Utility;
 
 namespace brainbeats_backend.GremlinQueries {
   public static class BeatQueries {
-    public static async Task<ResultSet<dynamic>> CreateBeatVertexQuery(string email, BeatVertex b, string seed = null) {
+    public static async Task<ResultSet<dynamic>> CreateBeatVertexQuery(string email, BeatVertex b, string seed) {
       string beatId = Guid.NewGuid().ToString();
       StringBuilder queryString = new StringBuilder(CreateVertex("beat", beatId));
 
-      try {
-        foreach (PropertyInfo prop in b.GetType().GetProperties()) {
-          // Skip null or empty fields
-          if (prop.GetValue(b) == null || string.IsNullOrWhiteSpace(prop.GetValue(b).ToString())) {
-            throw new ArgumentException($"{prop.Name} must not be empty");
-          }
-
-          queryString.Append(await SetField(prop, "beat", beatId, b).ConfigureAwait(false));
+      foreach (PropertyInfo prop in b.GetType().GetProperties()) {
+        // Skip null or empty fields
+        if (prop.GetValue(b) == null || string.IsNullOrWhiteSpace(prop.GetValue(b).ToString())) {
+          throw new ArgumentException($"{prop.Name} must not be empty");
         }
 
-        if (!string.IsNullOrWhiteSpace(seed)) {
-          queryString.Append(AddProperty("seed", seed));
-        }
-
-        queryString.Append(CreateEdge("OWNED_BY", email) + EdgeSourceReference());
-      } catch {
-        throw;
+        queryString.Append(await SetField(prop, "beat", beatId, b).ConfigureAwait(false));
       }
 
-      try {
-        return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
-      } catch {
-        throw;
+      if (!string.IsNullOrWhiteSpace(seed)) {
+        queryString.Append(AddProperty("seed", seed));
       }
+
+      queryString.Append(CreateEdge("OWNED_BY", email) + EdgeSourceReference());
+
+      return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
     }
 
     public static async Task<ResultSet<dynamic>> UpdateBeatVertexQuery(string beatId, BeatVertex b) {
       StringBuilder queryString = new StringBuilder(GetVertex(beatId));
 
-      try {
-        foreach (PropertyInfo prop in b.GetType().GetProperties()) {
-          // Skip null or empty fields
-          if (prop.GetValue(b) == null || string.IsNullOrWhiteSpace(prop.GetValue(b).ToString())) {
-            continue;
-          }
-
-          queryString.Append(await SetField(prop, "beat", beatId, b).ConfigureAwait(false));
+      foreach (PropertyInfo prop in b.GetType().GetProperties()) {
+        // Skip null or empty fields
+        if (prop.GetValue(b) == null || string.IsNullOrWhiteSpace(prop.GetValue(b).ToString())) {
+          continue;
         }
-      } catch {
-        throw;
+
+        queryString.Append(await SetField(prop, "beat", beatId, b).ConfigureAwait(false));
       }
 
-      try {
-        return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
-      } catch {
-        throw;
-      }
+      return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
     }
 
-    public static async Task<List<dynamic>> SearchBeatVertexQuery(string name = null, string email = null) {
-      try {
-        // If name and email is null, get public Beats
-        if (string.IsNullOrWhiteSpace(name) && string.IsNullOrWhiteSpace(email)) {
-          string queryString = GetAllPublicVerticesQuery("beat");
+    public static async Task<List<dynamic>> SearchBeatVertexQuery(string name, string email) {
+      // If name and email is null, get public Beats
+      if (string.IsNullOrWhiteSpace(name) && string.IsNullOrWhiteSpace(email)) {
+        string queryString = GetAllPublicVerticesQuery("beat");
 
-          ResultSet<dynamic> result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-
-          List<dynamic> resultList = await PopulatePlaylistLength(result);
-          resultList = await PopulateVertexOwners(resultList);
-
-          return resultList;
-        }
-        // If name is not null and email is null, search public Beats
-        else if (!string.IsNullOrWhiteSpace(name) && string.IsNullOrWhiteSpace(email)) {
-          string queryString = SearchPublicVertexQuery("beat", name);
-
-          ResultSet<dynamic> result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-
-          List<dynamic> resultList = await PopulatePlaylistLength(result);
-          resultList = await PopulateVertexOwners(resultList);
-
-          return resultList;
-        }
-        // If name is null and email is not null, get public and owned Beats
-        else if (string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(email)) {
-          string queryStringPublic = GetAllPublicVerticesQuery("beat");
-          string queryStringPrivate = GetAllOwnedVerticesQuery("beat", email);
-
-          ResultSet<dynamic> resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
-          ResultSet<dynamic> resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
-
-          List<dynamic> resultList = await PopulateVertexOwners(resultsPublic.Concat(resultsPrivate));
-
-          return resultList;
-        }
-        // If name and email is not null, search public and owned Beats
-        else {
-          string queryStringPublic = SearchPublicVertexQuery("beat", name);
-          string queryStringPrivate = SearchOwnedVertexQuery("beat", email, name);
-
-          ResultSet<dynamic> resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
-          ResultSet<dynamic> resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
-
-          List<dynamic> resultList = await PopulateVertexOwners(resultsPublic.Concat(resultsPrivate));
-
-          return resultList;
-        }
-      } catch {
-        throw;
-      }
-    }
-
-    public static async Task<List<dynamic>> ReadBeatVertexQuery(string beatId) {
-      string queryString = GetVertex(beatId);
-
-      try {
         ResultSet<dynamic> result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
 
         List<dynamic> resultList = await PopulatePlaylistLength(result);
         resultList = await PopulateVertexOwners(resultList);
 
         return resultList;
-      } catch {
-        throw;
       }
+      // If name is not null and email is null, search public Beats
+      else if (!string.IsNullOrWhiteSpace(name) && string.IsNullOrWhiteSpace(email)) {
+        string queryString = SearchPublicVertexQuery("beat", name);
+
+        ResultSet<dynamic> result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+
+        List<dynamic> resultList = await PopulatePlaylistLength(result);
+        resultList = await PopulateVertexOwners(resultList);
+
+        return resultList;
+      }
+      // If name is null and email is not null, get public and owned Beats
+      else if (string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(email)) {
+        string queryStringPublic = GetAllPublicVerticesQuery("beat");
+        string queryStringPrivate = GetAllOwnedVerticesQuery("beat", email);
+
+        ResultSet<dynamic> resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
+        ResultSet<dynamic> resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
+
+        List<dynamic> resultList = await PopulateVertexOwners(resultsPublic.Concat(resultsPrivate));
+
+        return resultList;
+      }
+      // If name and email is not null, search public and owned Beats
+      else {
+        string queryStringPublic = SearchPublicVertexQuery("beat", name);
+        string queryStringPrivate = SearchOwnedVertexQuery("beat", email, name);
+
+        ResultSet<dynamic> resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
+        ResultSet<dynamic> resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
+
+        List<dynamic> resultList = await PopulateVertexOwners(resultsPublic.Concat(resultsPrivate));
+
+          return resultList;
+        }
+    }
+
+    public static async Task<List<dynamic>> ReadBeatVertexQuery(string beatId) {
+      string queryString = GetVertex(beatId);
+
+      ResultSet<dynamic> result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+
+      List<dynamic> resultList = await PopulatePlaylistLength(result);
+      resultList = await PopulateVertexOwners(resultList);
+
+      return resultList;
     }
 
     public static async Task<ResultSet<dynamic>> DeleteBeatVertexQuery(string beatId) {
       string queryString = GetVertex(beatId) + Delete();
 
-      try {
-        // Delete the png or jpg picture associated with this Beat
-        await StorageConnection.Instance.DeleteFileAsync("beat", $"{beatId}_image.jpg");
-        await StorageConnection.Instance.DeleteFileAsync("beat", $"{beatId}_image.png");
+      // Delete the png or jpg picture associated with this Beat
+      await StorageConnection.Instance.DeleteFileAsync("beat", $"{beatId}_image.jpg");
+      await StorageConnection.Instance.DeleteFileAsync("beat", $"{beatId}_image.png");
 
-        // Delete the wav or mp3 audio associated with this Beat
-        await StorageConnection.Instance.DeleteFileAsync("beat", $"{beatId}_audio.wav");
-        await StorageConnection.Instance.DeleteFileAsync("beat", $"{beatId}_audio.mp3");
+      // Delete the wav or mp3 audio associated with this Beat
+      await StorageConnection.Instance.DeleteFileAsync("beat", $"{beatId}_audio.wav");
+      await StorageConnection.Instance.DeleteFileAsync("beat", $"{beatId}_audio.mp3");
 
-        return await DatabaseConnection.Instance.ExecuteQuery(queryString);
-      } catch {
-        throw;
-      }
+      return await DatabaseConnection.Instance.ExecuteQuery(queryString);
     }
   }
 }

--- a/brainbeats-backend/GremlinQueries/BeatQueries.cs
+++ b/brainbeats-backend/GremlinQueries/BeatQueries.cs
@@ -1,0 +1,154 @@
+﻿using brainbeats_backend.Controllers;
+using Gremlin.Net.Driver;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using static brainbeats_backend.QueryBuilder;
+using static brainbeats_backend.QueryStrings;
+using static brainbeats_backend.Utility;
+
+namespace brainbeats_backend.GremlinQueries {
+  public static class BeatQueries {
+    public static async Task<ResultSet<dynamic>> CreateBeatVertexQuery(string email, BeatVertex b, string seed = null) {
+      string beatId = Guid.NewGuid().ToString();
+      StringBuilder queryString = new StringBuilder(CreateVertex("beat", beatId));
+
+      try {
+        foreach (PropertyInfo prop in b.GetType().GetProperties()) {
+          // Skip null or empty fields
+          if (prop.GetValue(b) == null || string.IsNullOrWhiteSpace(prop.GetValue(b).ToString())) {
+            throw new ArgumentException($"{prop.Name} must not be empty");
+          }
+
+          queryString.Append(await SetField(prop, "beat", beatId, b).ConfigureAwait(false));
+        }
+
+        if (!string.IsNullOrWhiteSpace(seed)) {
+          queryString.Append(AddProperty("seed", seed));
+        }
+
+        queryString.Append(CreateEdge("OWNED_BY", email) + EdgeSourceReference());
+      } catch {
+        throw;
+      }
+
+      try {
+        return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
+      } catch {
+        throw;
+      }
+    }
+
+    public static async Task<ResultSet<dynamic>> UpdateBeatVertexQuery(string beatId, BeatVertex b) {
+      StringBuilder queryString = new StringBuilder(GetVertex(beatId));
+
+      try {
+        foreach (PropertyInfo prop in b.GetType().GetProperties()) {
+          // Skip null or empty fields
+          if (prop.GetValue(b) == null || string.IsNullOrWhiteSpace(prop.GetValue(b).ToString())) {
+            continue;
+          }
+
+          queryString.Append(await SetField(prop, "beat", beatId, b).ConfigureAwait(false));
+        }
+      } catch {
+        throw;
+      }
+
+      try {
+        return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
+      } catch {
+        throw;
+      }
+    }
+
+    public static async Task<List<dynamic>> SearchBeatVertexQuery(string name = null, string email = null) {
+      try {
+        // If name and email is null, get public Beats
+        if (string.IsNullOrWhiteSpace(name) && string.IsNullOrWhiteSpace(email)) {
+          string queryString = GetAllPublicVerticesQuery("beat");
+
+          ResultSet<dynamic> result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+
+          List<dynamic> resultList = await PopulatePlaylistLength(result);
+          resultList = await PopulateVertexOwners(resultList);
+
+          return resultList;
+        }
+        // If name is not null and email is null, search public Beats
+        else if (!string.IsNullOrWhiteSpace(name) && string.IsNullOrWhiteSpace(email)) {
+          string queryString = SearchPublicVertexQuery("beat", name);
+
+          ResultSet<dynamic> result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+
+          List<dynamic> resultList = await PopulatePlaylistLength(result);
+          resultList = await PopulateVertexOwners(resultList);
+
+          return resultList;
+        }
+        // If name is null and email is not null, get public and owned Beats
+        else if (string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(email)) {
+          string queryStringPublic = GetAllPublicVerticesQuery("beat");
+          string queryStringPrivate = GetAllOwnedVerticesQuery("beat", email);
+
+          ResultSet<dynamic> resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
+          ResultSet<dynamic> resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
+
+          List<dynamic> resultList = await PopulateVertexOwners(resultsPublic.Concat(resultsPrivate));
+
+          return resultList;
+        }
+        // If name and email is not null, search public and owned Beats
+        else {
+          string queryStringPublic = SearchPublicVertexQuery("beat", name);
+          string queryStringPrivate = SearchOwnedVertexQuery("beat", email, name);
+
+          ResultSet<dynamic> resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
+          ResultSet<dynamic> resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
+
+          List<dynamic> resultList = await PopulateVertexOwners(resultsPublic.Concat(resultsPrivate));
+
+          return resultList;
+        }
+      } catch {
+        throw;
+      }
+    }
+
+    public static async Task<List<dynamic>> ReadBeatVertexQuery(string beatId) {
+      string queryString = GetVertex(beatId);
+
+      try {
+        ResultSet<dynamic> result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+
+        List<dynamic> resultList = await PopulatePlaylistLength(result);
+        resultList = await PopulateVertexOwners(resultList);
+
+        return resultList;
+      } catch {
+        throw;
+      }
+    }
+
+    public static async Task<ResultSet<dynamic>> DeleteBeatVertexQuery(string beatId) {
+      string queryString = GetVertex(beatId) + Delete();
+
+      try {
+        // Delete the png or jpg picture associated with this Beat
+        await StorageConnection.Instance.DeleteFileAsync("beat", $"{beatId}_image.jpg");
+        await StorageConnection.Instance.DeleteFileAsync("beat", $"{beatId}_image.png");
+
+        // Delete the wav or mp3 audio associated with this Beat
+        await StorageConnection.Instance.DeleteFileAsync("beat", $"{beatId}_audio.wav");
+        await StorageConnection.Instance.DeleteFileAsync("beat", $"{beatId}_audio.mp3");
+
+        return await DatabaseConnection.Instance.ExecuteQuery(queryString);
+      } catch {
+        throw;
+      }
+    }
+  }
+}

--- a/brainbeats-backend/GremlinQueries/PlaylistQueries.cs
+++ b/brainbeats-backend/GremlinQueries/PlaylistQueries.cs
@@ -12,162 +12,126 @@ using static brainbeats_backend.Utility;
 
 namespace brainbeats_backend.GremlinQueries {
   public static class PlaylistQueries {
-    public static async Task<ResultSet<dynamic>> CreatePlaylistVertexQuery(string email, PlaylistVertex p, string seed = null) {
+    public static async Task<ResultSet<dynamic>> CreatePlaylistVertexQuery(string email, PlaylistVertex p, string seed) {
       string playlistId = Guid.NewGuid().ToString();
       email = email.ToLowerInvariant();
 
       StringBuilder queryString = new StringBuilder(CreateVertex("playlist", playlistId));
 
-      try {
-        foreach (PropertyInfo prop in p.GetType().GetProperties()) {
-          // Skip null or empty fields
-          if (prop.GetValue(p) == null || string.IsNullOrWhiteSpace(prop.GetValue(p).ToString())) {
-            throw new ArgumentException($"{prop.Name} must not be empty");
-          }
-
-          queryString.Append(await SetField(prop, "playlist", playlistId, p).ConfigureAwait(false));
+      foreach (PropertyInfo prop in p.GetType().GetProperties()) {
+        // Skip null or empty fields
+        if (prop.GetValue(p) == null || string.IsNullOrWhiteSpace(prop.GetValue(p).ToString())) {
+          throw new ArgumentException($"{prop.Name} must not be empty");
         }
 
-        if (!string.IsNullOrWhiteSpace(seed)) {
-          queryString.Append(AddProperty("seed", seed));
-        }
-
-        queryString.Append(CreateEdge("OWNED_BY", email) + EdgeSourceReference());
-      } catch {
-        throw;
+        queryString.Append(await SetField(prop, "playlist", playlistId, p).ConfigureAwait(false));
       }
 
-      try {
-        return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
-      } catch {
-        throw;
+      if (!string.IsNullOrWhiteSpace(seed)) {
+        queryString.Append(AddProperty("seed", seed));
       }
+
+      queryString.Append(CreateEdge("OWNED_BY", email) + EdgeSourceReference());
+
+      return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
     }
 
     public static async Task<ResultSet<dynamic>> UpdatePlaylistVertexQuery(string playlistId, PlaylistVertex p) {
       StringBuilder queryString = new StringBuilder(GetVertex(playlistId));
 
-      try {
-        foreach (PropertyInfo prop in p.GetType().GetProperties()) {
-          // Skip null or empty fields
-          if (prop.GetValue(p) == null || string.IsNullOrWhiteSpace(prop.GetValue(p).ToString())) {
-            continue;
-          }
-
-          queryString.Append(await SetField(prop, "playlist", playlistId, p).ConfigureAwait(false));
+      foreach (PropertyInfo prop in p.GetType().GetProperties()) {
+        // Skip null or empty fields
+        if (prop.GetValue(p) == null || string.IsNullOrWhiteSpace(prop.GetValue(p).ToString())) {
+          continue;
         }
-      } catch {
-        throw;
+
+        queryString.Append(await SetField(prop, "playlist", playlistId, p).ConfigureAwait(false));
       }
 
-      try {
-        return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
-      } catch {
-        throw;
-      }
+      return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
     }
 
-    public static async Task<List<dynamic>> SearchPlaylistVertexQuery(string name = null, string email = null) {
-      try {
-        // If name and email is null, get public Beats
-        if (string.IsNullOrWhiteSpace(name) && string.IsNullOrWhiteSpace(email)) {
-          string queryString = GetAllPublicVerticesQuery("playlist");
-          var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+    public static async Task<List<dynamic>> SearchPlaylistVertexQuery(string name, string email) {
+      // If name and email is null, get public Beats
+      if (string.IsNullOrWhiteSpace(name) && string.IsNullOrWhiteSpace(email)) {
+        string queryString = GetAllPublicVerticesQuery("playlist");
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
 
-          List<dynamic> resultList = await PopulatePlaylistLength(result);
-          resultList = await PopulateVertexOwners(resultList);
+        List<dynamic> resultList = await PopulatePlaylistLength(result);
+        resultList = await PopulateVertexOwners(resultList);
 
-          return resultList;
-        }
-        // If name is not null and email is null, search public Beats
-        else if (!string.IsNullOrWhiteSpace(name) && string.IsNullOrWhiteSpace(email)) {
-          string queryString = SearchPublicVertexQuery("playlist", name);
-          var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+        return resultList;
+      }
+      // If name is not null and email is null, search public Beats
+      else if (!string.IsNullOrWhiteSpace(name) && string.IsNullOrWhiteSpace(email)) {
+        string queryString = SearchPublicVertexQuery("playlist", name);
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
 
-          List<dynamic> resultList = await PopulatePlaylistLength(result);
-          resultList = await PopulateVertexOwners(resultList);
+        List<dynamic> resultList = await PopulatePlaylistLength(result);
+        resultList = await PopulateVertexOwners(resultList);
 
-          return resultList;
-        }
-        // If name is null and email is not null, get public and owned Beats
-        else if (string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(email)) {
-          string queryStringPublic = GetAllPublicVerticesQuery("playlist");
-          string queryStringPrivate = GetAllOwnedVerticesQuery("playlist", email);
+        return resultList;
+      }
+      // If name is null and email is not null, get public and owned Beats
+      else if (string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(email)) {
+        string queryStringPublic = GetAllPublicVerticesQuery("playlist");
+        string queryStringPrivate = GetAllOwnedVerticesQuery("playlist", email);
 
-          var resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
-          var resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
-          var result = resultsPublic.Concat(resultsPrivate);
+        var resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
+        var resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
+        var result = resultsPublic.Concat(resultsPrivate);
 
-          List<dynamic> resultList = await PopulatePlaylistLength(result);
-          resultList = await PopulateVertexOwners(resultList);
+        List<dynamic> resultList = await PopulatePlaylistLength(result);
+        resultList = await PopulateVertexOwners(resultList);
 
-          return resultList;
-        }
-        // If name and email is not null, search public and owned Beats
-        else {
-          string queryStringPublic = SearchPublicVertexQuery("playlist", name);
-          string queryStringPrivate = SearchOwnedVertexQuery("playlist", email, name);
+        return resultList;
+      }
+      // If name and email is not null, search public and owned Beats
+      else {
+        string queryStringPublic = SearchPublicVertexQuery("playlist", name);
+        string queryStringPrivate = SearchOwnedVertexQuery("playlist", email, name);
 
-          var resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
-          var resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
-          var result = resultsPublic.Concat(resultsPrivate);
+        var resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
+        var resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
+        var result = resultsPublic.Concat(resultsPrivate);
 
-          List<dynamic> resultList = await PopulatePlaylistLength(result);
-          resultList = await PopulateVertexOwners(resultList);
+        List<dynamic> resultList = await PopulatePlaylistLength(result);
+        resultList = await PopulateVertexOwners(resultList);
 
-          return resultList;
-        }
-      } catch {
-        throw;
+        return resultList;
       }
     }
 
     public static async Task<ResultSet<dynamic>> UpdatePlaylistAddBeat(string playlistId, string beatId) {
       string queryString = CreateOutNeighborQuery("CONTAINS", playlistId, beatId);
 
-      try {
-        return await DatabaseConnection.Instance.ExecuteQuery(queryString);
-      } catch {
-        throw;
-      }
+      return await DatabaseConnection.Instance.ExecuteQuery(queryString);
     }
 
     public static async Task<ResultSet<dynamic>> UpdatePlaylistRemoveBeat(string playlistId, string beatId) {
       string queryString = DeleteOutNeighborQuery("CONTAINS", playlistId, beatId);
 
-      try {
-        return await DatabaseConnection.Instance.ExecuteQuery(queryString);
-      } catch {
-        throw;
-      }
+      return await DatabaseConnection.Instance.ExecuteQuery(queryString);
     }
 
     public static async Task<List<dynamic>> ReadPlaylistVertexQuery(string playlistId) {
       string queryString = GetVertex(playlistId);
 
-      try {
-        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-        List<dynamic> resultList = await PopulatePlaylistLength(result);
-        resultList = await PopulateVertexOwners(resultList);
+      var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+      List<dynamic> resultList = await PopulatePlaylistLength(result);
+      resultList = await PopulateVertexOwners(resultList);
 
-        return resultList;
-      } catch {
-        throw;
-      }
+      return resultList;
     }
 
     public static async Task<ResultSet<dynamic>> DeletePlaylistVertexQuery(string playlistId) {
       string queryString = GetVertex(playlistId) + Delete();
 
-      try {
-        // Delete the png or jpg picture associated with this Playlist
-        await StorageConnection.Instance.DeleteFileAsync("playlist", $"{playlistId}_image.jpg");
-        await StorageConnection.Instance.DeleteFileAsync("playlist", $"{playlistId}_image.png");
+      // Delete the png or jpg picture associated with this Playlist
+      await StorageConnection.Instance.DeleteFileAsync("playlist", $"{playlistId}_image.jpg");
+      await StorageConnection.Instance.DeleteFileAsync("playlist", $"{playlistId}_image.png");
 
-        return await DatabaseConnection.Instance.ExecuteQuery(queryString);
-      } catch {
-        throw;
-      }
+      return await DatabaseConnection.Instance.ExecuteQuery(queryString);
     }
   }
 }

--- a/brainbeats-backend/GremlinQueries/PlaylistQueries.cs
+++ b/brainbeats-backend/GremlinQueries/PlaylistQueries.cs
@@ -1,0 +1,173 @@
+﻿using brainbeats_backend.Controllers;
+using Gremlin.Net.Driver;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using static brainbeats_backend.QueryBuilder;
+using static brainbeats_backend.QueryStrings;
+using static brainbeats_backend.Utility;
+
+namespace brainbeats_backend.GremlinQueries {
+  public static class PlaylistQueries {
+    public static async Task<ResultSet<dynamic>> CreatePlaylistVertexQuery(string email, PlaylistVertex p, string seed = null) {
+      string playlistId = Guid.NewGuid().ToString();
+      email = email.ToLowerInvariant();
+
+      StringBuilder queryString = new StringBuilder(CreateVertex("playlist", playlistId));
+
+      try {
+        foreach (PropertyInfo prop in p.GetType().GetProperties()) {
+          // Skip null or empty fields
+          if (prop.GetValue(p) == null || string.IsNullOrWhiteSpace(prop.GetValue(p).ToString())) {
+            throw new ArgumentException($"{prop.Name} must not be empty");
+          }
+
+          queryString.Append(await SetField(prop, "playlist", playlistId, p).ConfigureAwait(false));
+        }
+
+        if (!string.IsNullOrWhiteSpace(seed)) {
+          queryString.Append(AddProperty("seed", seed));
+        }
+
+        queryString.Append(CreateEdge("OWNED_BY", email) + EdgeSourceReference());
+      } catch {
+        throw;
+      }
+
+      try {
+        return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
+      } catch {
+        throw;
+      }
+    }
+
+    public static async Task<ResultSet<dynamic>> UpdatePlaylistVertexQuery(string playlistId, PlaylistVertex p) {
+      StringBuilder queryString = new StringBuilder(GetVertex(playlistId));
+
+      try {
+        foreach (PropertyInfo prop in p.GetType().GetProperties()) {
+          // Skip null or empty fields
+          if (prop.GetValue(p) == null || string.IsNullOrWhiteSpace(prop.GetValue(p).ToString())) {
+            continue;
+          }
+
+          queryString.Append(await SetField(prop, "playlist", playlistId, p).ConfigureAwait(false));
+        }
+      } catch {
+        throw;
+      }
+
+      try {
+        return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
+      } catch {
+        throw;
+      }
+    }
+
+    public static async Task<List<dynamic>> SearchPlaylistVertexQuery(string name = null, string email = null) {
+      try {
+        // If name and email is null, get public Beats
+        if (string.IsNullOrWhiteSpace(name) && string.IsNullOrWhiteSpace(email)) {
+          string queryString = GetAllPublicVerticesQuery("playlist");
+          var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+
+          List<dynamic> resultList = await PopulatePlaylistLength(result);
+          resultList = await PopulateVertexOwners(resultList);
+
+          return resultList;
+        }
+        // If name is not null and email is null, search public Beats
+        else if (!string.IsNullOrWhiteSpace(name) && string.IsNullOrWhiteSpace(email)) {
+          string queryString = SearchPublicVertexQuery("playlist", name);
+          var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+
+          List<dynamic> resultList = await PopulatePlaylistLength(result);
+          resultList = await PopulateVertexOwners(resultList);
+
+          return resultList;
+        }
+        // If name is null and email is not null, get public and owned Beats
+        else if (string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(email)) {
+          string queryStringPublic = GetAllPublicVerticesQuery("playlist");
+          string queryStringPrivate = GetAllOwnedVerticesQuery("playlist", email);
+
+          var resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
+          var resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
+          var result = resultsPublic.Concat(resultsPrivate);
+
+          List<dynamic> resultList = await PopulatePlaylistLength(result);
+          resultList = await PopulateVertexOwners(resultList);
+
+          return resultList;
+        }
+        // If name and email is not null, search public and owned Beats
+        else {
+          string queryStringPublic = SearchPublicVertexQuery("playlist", name);
+          string queryStringPrivate = SearchOwnedVertexQuery("playlist", email, name);
+
+          var resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
+          var resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
+          var result = resultsPublic.Concat(resultsPrivate);
+
+          List<dynamic> resultList = await PopulatePlaylistLength(result);
+          resultList = await PopulateVertexOwners(resultList);
+
+          return resultList;
+        }
+      } catch {
+        throw;
+      }
+    }
+
+    public static async Task<ResultSet<dynamic>> UpdatePlaylistAddBeat(string playlistId, string beatId) {
+      string queryString = CreateOutNeighborQuery("CONTAINS", playlistId, beatId);
+
+      try {
+        return await DatabaseConnection.Instance.ExecuteQuery(queryString);
+      } catch {
+        throw;
+      }
+    }
+
+    public static async Task<ResultSet<dynamic>> UpdatePlaylistRemoveBeat(string playlistId, string beatId) {
+      string queryString = DeleteOutNeighborQuery("CONTAINS", playlistId, beatId);
+
+      try {
+        return await DatabaseConnection.Instance.ExecuteQuery(queryString);
+      } catch {
+        throw;
+      }
+    }
+
+    public static async Task<List<dynamic>> ReadPlaylistVertexQuery(string playlistId) {
+      string queryString = GetVertex(playlistId);
+
+      try {
+        var result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+        List<dynamic> resultList = await PopulatePlaylistLength(result);
+        resultList = await PopulateVertexOwners(resultList);
+
+        return resultList;
+      } catch {
+        throw;
+      }
+    }
+
+    public static async Task<ResultSet<dynamic>> DeletePlaylistVertexQuery(string playlistId) {
+      string queryString = GetVertex(playlistId) + Delete();
+
+      try {
+        // Delete the png or jpg picture associated with this Playlist
+        await StorageConnection.Instance.DeleteFileAsync("playlist", $"{playlistId}_image.jpg");
+        await StorageConnection.Instance.DeleteFileAsync("playlist", $"{playlistId}_image.png");
+
+        return await DatabaseConnection.Instance.ExecuteQuery(queryString);
+      } catch {
+        throw;
+      }
+    }
+  }
+}

--- a/brainbeats-backend/GremlinQueries/SampleQueries.cs
+++ b/brainbeats-backend/GremlinQueries/SampleQueries.cs
@@ -1,0 +1,148 @@
+﻿using brainbeats_backend.Controllers;
+using Gremlin.Net.Driver;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using static brainbeats_backend.QueryBuilder;
+using static brainbeats_backend.QueryStrings;
+using static brainbeats_backend.Utility;
+
+namespace brainbeats_backend.GremlinQueries {
+  public static class SampleQueries {
+    public static async Task<ResultSet<dynamic>> CreateSampleVertexQuery(string email, SampleVertex p, string seed = null) {
+      string sampleId = Guid.NewGuid().ToString();
+      email = email.ToLowerInvariant();
+
+      StringBuilder queryString = new StringBuilder(CreateVertex("sample", sampleId));
+
+      try {
+        foreach (PropertyInfo prop in p.GetType().GetProperties()) {
+          // Skip null or empty fields
+          if (prop.GetValue(p) == null || string.IsNullOrWhiteSpace(prop.GetValue(p).ToString())) {
+            throw new ArgumentException($"{prop.Name} must not be empty");
+          }
+
+          queryString.Append(await SetField(prop, "sample", sampleId, p).ConfigureAwait(false));
+        }
+
+        if (!string.IsNullOrWhiteSpace(seed)) {
+          queryString.Append(AddProperty("seed", seed));
+        }
+
+        queryString.Append(CreateEdge("OWNED_BY", email) + EdgeSourceReference());
+      } catch {
+        throw;
+      }
+
+      try {
+        return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
+      } catch {
+        throw;
+      }
+    }
+
+    public static async Task<ResultSet<dynamic>> UpdateSampleVertexQuery(string sampleId, SampleVertex p) {
+      StringBuilder queryString = new StringBuilder(GetVertex(sampleId));
+
+      try {
+        foreach (PropertyInfo prop in p.GetType().GetProperties()) {
+          // Skip null or empty fields
+          if (prop.GetValue(p) == null || string.IsNullOrWhiteSpace(prop.GetValue(p).ToString())) {
+            continue;
+          }
+
+          queryString.Append(await SetField(prop, "sample", sampleId, p).ConfigureAwait(false));
+        }
+      } catch {
+        throw;
+      }
+
+      try {
+        return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
+      } catch {
+        throw;
+      }
+    }
+
+    public static async Task<List<dynamic>> SearchSampleVertexQuery(string name = null, string email = null) {
+      try {
+        // If name and email is null, get public Beats
+        if (string.IsNullOrWhiteSpace(name) && string.IsNullOrWhiteSpace(email)) {
+          string queryString = GetAllPublicVerticesQuery("sample");
+
+          ResultSet<dynamic> result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+
+          List<dynamic> resultList = await PopulatePlaylistLength(result);
+          resultList = await PopulateVertexOwners(resultList);
+
+          return resultList;
+        }
+        // If name is not null and email is null, search public Beats
+        else if (!string.IsNullOrWhiteSpace(name) && string.IsNullOrWhiteSpace(email)) {
+          string queryString = SearchPublicVertexQuery("sample", name);
+
+          ResultSet<dynamic> result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+
+          List<dynamic> resultList = await PopulatePlaylistLength(result);
+          resultList = await PopulateVertexOwners(resultList);
+
+          return resultList;
+        }
+        // If name is null and email is not null, get public and owned Beats
+        else if (string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(email)) {
+          string queryStringPublic = GetAllPublicVerticesQuery("sample");
+          string queryStringPrivate = GetAllOwnedVerticesQuery("sample", email);
+
+          ResultSet<dynamic> resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
+          ResultSet<dynamic> resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
+
+          List<dynamic> resultList = await PopulateVertexOwners(resultsPublic.Concat(resultsPrivate));
+          return resultList;
+        }
+        // If name and email is not null, search public and owned Beats
+        else {
+          string queryStringPublic = SearchPublicVertexQuery("sample", name);
+          string queryStringPrivate = SearchOwnedVertexQuery("sample", email, name);
+
+          ResultSet<dynamic> resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
+          ResultSet<dynamic> resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
+
+          List<dynamic> resultList = await PopulateVertexOwners(resultsPublic.Concat(resultsPrivate));
+          return resultList;
+        }
+      } catch {
+        throw;
+      }
+    }
+
+    public static async Task<List<dynamic>> ReadSampleVertexQuery(string sampleId) {
+      string queryString = GetVertex(sampleId);
+
+      try {
+        ResultSet<dynamic> result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+
+        List<dynamic> resultList = await PopulatePlaylistLength(result);
+        resultList = await PopulateVertexOwners(resultList);
+
+        return resultList;
+      } catch {
+        throw;
+      }
+    }
+
+    public static async Task<ResultSet<dynamic>> DeleteSampleVertexQuery(string sampleId) {
+      string queryString = GetVertex(sampleId) + Delete();
+
+      try {
+        // IMPORTANT: Don't delete Sample audio files when deleting Sample vertices
+
+        return await DatabaseConnection.Instance.ExecuteQuery(queryString);
+      } catch {
+        throw;
+      }
+    }
+  }
+}

--- a/brainbeats-backend/GremlinQueries/SampleQueries.cs
+++ b/brainbeats-backend/GremlinQueries/SampleQueries.cs
@@ -12,137 +12,110 @@ using static brainbeats_backend.Utility;
 
 namespace brainbeats_backend.GremlinQueries {
   public static class SampleQueries {
-    public static async Task<ResultSet<dynamic>> CreateSampleVertexQuery(string email, SampleVertex p, string seed = null) {
+    public static async Task<ResultSet<dynamic>> CreateSampleVertexQuery(string email, SampleVertex p, string seed) {
       string sampleId = Guid.NewGuid().ToString();
       email = email.ToLowerInvariant();
 
       StringBuilder queryString = new StringBuilder(CreateVertex("sample", sampleId));
 
-      try {
-        foreach (PropertyInfo prop in p.GetType().GetProperties()) {
-          // Skip null or empty fields
-          if (prop.GetValue(p) == null || string.IsNullOrWhiteSpace(prop.GetValue(p).ToString())) {
-            throw new ArgumentException($"{prop.Name} must not be empty");
-          }
-
-          queryString.Append(await SetField(prop, "sample", sampleId, p).ConfigureAwait(false));
+      foreach (PropertyInfo prop in p.GetType().GetProperties()) {
+        // Skip null or empty fields
+        if (prop.GetValue(p) == null || string.IsNullOrWhiteSpace(prop.GetValue(p).ToString())) {
+          throw new ArgumentException($"{prop.Name} must not be empty");
         }
 
-        if (!string.IsNullOrWhiteSpace(seed)) {
-          queryString.Append(AddProperty("seed", seed));
-        }
-
-        queryString.Append(CreateEdge("OWNED_BY", email) + EdgeSourceReference());
-      } catch {
-        throw;
+        queryString.Append(await SetField(prop, "sample", sampleId, p).ConfigureAwait(false));
       }
 
-      try {
-        return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
-      } catch {
-        throw;
+      if (!string.IsNullOrWhiteSpace(seed)) {
+        queryString.Append(AddProperty("seed", seed));
       }
+
+      queryString.Append(CreateEdge("OWNED_BY", email) + EdgeSourceReference());
+
+      return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
     }
 
     public static async Task<ResultSet<dynamic>> UpdateSampleVertexQuery(string sampleId, SampleVertex p) {
       StringBuilder queryString = new StringBuilder(GetVertex(sampleId));
 
-      try {
-        foreach (PropertyInfo prop in p.GetType().GetProperties()) {
-          // Skip null or empty fields
-          if (prop.GetValue(p) == null || string.IsNullOrWhiteSpace(prop.GetValue(p).ToString())) {
-            continue;
-          }
-
-          queryString.Append(await SetField(prop, "sample", sampleId, p).ConfigureAwait(false));
+      foreach (PropertyInfo prop in p.GetType().GetProperties()) {
+        // Skip null or empty fields
+        if (prop.GetValue(p) == null || string.IsNullOrWhiteSpace(prop.GetValue(p).ToString())) {
+          continue;
         }
-      } catch {
-        throw;
+
+        queryString.Append(await SetField(prop, "sample", sampleId, p).ConfigureAwait(false));
       }
 
-      try {
-        return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
-      } catch {
-        throw;
-      }
+      return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
     }
 
-    public static async Task<List<dynamic>> SearchSampleVertexQuery(string name = null, string email = null) {
-      try {
-        // If name and email is null, get public Beats
-        if (string.IsNullOrWhiteSpace(name) && string.IsNullOrWhiteSpace(email)) {
-          string queryString = GetAllPublicVerticesQuery("sample");
+    public static async Task<List<dynamic>> SearchSampleVertexQuery(string name, string email) {
+      // If name and email is null, get public Beats
+      if (string.IsNullOrWhiteSpace(name) && string.IsNullOrWhiteSpace(email)) {
+        string queryString = GetAllPublicVerticesQuery("sample");
 
-          ResultSet<dynamic> result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-
-          List<dynamic> resultList = await PopulatePlaylistLength(result);
-          resultList = await PopulateVertexOwners(resultList);
-
-          return resultList;
-        }
-        // If name is not null and email is null, search public Beats
-        else if (!string.IsNullOrWhiteSpace(name) && string.IsNullOrWhiteSpace(email)) {
-          string queryString = SearchPublicVertexQuery("sample", name);
-
-          ResultSet<dynamic> result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
-
-          List<dynamic> resultList = await PopulatePlaylistLength(result);
-          resultList = await PopulateVertexOwners(resultList);
-
-          return resultList;
-        }
-        // If name is null and email is not null, get public and owned Beats
-        else if (string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(email)) {
-          string queryStringPublic = GetAllPublicVerticesQuery("sample");
-          string queryStringPrivate = GetAllOwnedVerticesQuery("sample", email);
-
-          ResultSet<dynamic> resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
-          ResultSet<dynamic> resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
-
-          List<dynamic> resultList = await PopulateVertexOwners(resultsPublic.Concat(resultsPrivate));
-          return resultList;
-        }
-        // If name and email is not null, search public and owned Beats
-        else {
-          string queryStringPublic = SearchPublicVertexQuery("sample", name);
-          string queryStringPrivate = SearchOwnedVertexQuery("sample", email, name);
-
-          ResultSet<dynamic> resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
-          ResultSet<dynamic> resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
-
-          List<dynamic> resultList = await PopulateVertexOwners(resultsPublic.Concat(resultsPrivate));
-          return resultList;
-        }
-      } catch {
-        throw;
-      }
-    }
-
-    public static async Task<List<dynamic>> ReadSampleVertexQuery(string sampleId) {
-      string queryString = GetVertex(sampleId);
-
-      try {
         ResultSet<dynamic> result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
 
         List<dynamic> resultList = await PopulatePlaylistLength(result);
         resultList = await PopulateVertexOwners(resultList);
 
         return resultList;
-      } catch {
-        throw;
       }
+      // If name is not null and email is null, search public Beats
+      else if (!string.IsNullOrWhiteSpace(name) && string.IsNullOrWhiteSpace(email)) {
+        string queryString = SearchPublicVertexQuery("sample", name);
+
+        ResultSet<dynamic> result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+
+        List<dynamic> resultList = await PopulatePlaylistLength(result);
+        resultList = await PopulateVertexOwners(resultList);
+
+        return resultList;
+      }
+      // If name is null and email is not null, get public and owned Beats
+      else if (string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(email)) {
+        string queryStringPublic = GetAllPublicVerticesQuery("sample");
+        string queryStringPrivate = GetAllOwnedVerticesQuery("sample", email);
+
+        ResultSet<dynamic> resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
+        ResultSet<dynamic> resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
+
+        List<dynamic> resultList = await PopulateVertexOwners(resultsPublic.Concat(resultsPrivate));
+        return resultList;
+      }
+      // If name and email is not null, search public and owned Beats
+      else {
+        string queryStringPublic = SearchPublicVertexQuery("sample", name);
+        string queryStringPrivate = SearchOwnedVertexQuery("sample", email, name);
+
+        ResultSet<dynamic> resultsPublic = await DatabaseConnection.Instance.ExecuteQuery(queryStringPublic);
+        ResultSet<dynamic> resultsPrivate = await DatabaseConnection.Instance.ExecuteQuery(queryStringPrivate);
+
+        List<dynamic> resultList = await PopulateVertexOwners(resultsPublic.Concat(resultsPrivate));
+        return resultList;
+      }
+    }
+
+    public static async Task<List<dynamic>> ReadSampleVertexQuery(string sampleId) {
+      string queryString = GetVertex(sampleId);
+
+      ResultSet<dynamic> result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+
+      List<dynamic> resultList = await PopulatePlaylistLength(result);
+      resultList = await PopulateVertexOwners(resultList);
+
+      return resultList;
+
     }
 
     public static async Task<ResultSet<dynamic>> DeleteSampleVertexQuery(string sampleId) {
       string queryString = GetVertex(sampleId) + Delete();
 
-      try {
-        // IMPORTANT: Don't delete Sample audio files when deleting Sample vertices
+      // IMPORTANT: Don't delete Sample audio files when deleting Sample vertices
 
-        return await DatabaseConnection.Instance.ExecuteQuery(queryString);
-      } catch {
-        throw;
-      }
+      return await DatabaseConnection.Instance.ExecuteQuery(queryString);
     }
   }
 }

--- a/brainbeats-backend/GremlinQueries/UserQueries.cs
+++ b/brainbeats-backend/GremlinQueries/UserQueries.cs
@@ -1,0 +1,152 @@
+﻿using brainbeats_backend.Controllers;
+using Gremlin.Net.Driver;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using static brainbeats_backend.QueryBuilder;
+using static brainbeats_backend.QueryStrings;
+using static brainbeats_backend.Utility;
+
+namespace brainbeats_backend.GremlinQueries {
+  public static class UserQueries {
+    private static readonly string defaultProfilePicture = $"{StorageConnection.Instance.StorageEndpoint}/static/profile_picture.png";
+    private static readonly HashSet<string> relationships = new HashSet<string>() { "LIKES", "RECOMMENDED", "OWNED_BY" };
+    private static readonly HashSet<string> types = new HashSet<string>() { "beat", "playlist", "sample" };
+
+    public static async Task<ResultSet<dynamic>> CreateUserVertexQuery(string email, UserVertex u) {
+      email = email.ToLowerInvariant();
+      StringBuilder queryString = new StringBuilder(CreateVertex("user", email));
+
+      try {
+        foreach (PropertyInfo prop in u.GetType().GetProperties()) {
+          // Skip "image" field for creating new users
+          if (prop.Name.ToLowerInvariant().Equals("image")) {
+            continue;
+          }
+
+          // Skip null or empty fields
+          if (prop.GetValue(u) == null || string.IsNullOrWhiteSpace(prop.GetValue(u).ToString())) {
+            throw new ArgumentException($"{prop.Name} must not be empty");
+          }
+
+          queryString.Append(await SetField(prop, "user", email, u).ConfigureAwait(false));
+        }
+
+        // Append the name field
+        string name = $"{u.firstName} {u.lastName}";
+        queryString.Append(AddProperty("name", name));
+
+        // Append the lowercase searchName field
+        queryString.Append(AddProperty("searchName", name.ToLowerInvariant()));
+
+        // Attach the default image to new users
+        queryString.Append(AddProperty("image", defaultProfilePicture));
+      } catch {
+        throw;
+      }
+
+      try {
+        return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
+      } catch {
+        throw;
+      }
+    }
+
+    public static async Task<dynamic> GetUserVertexNeighborsQuery(string email, string relationship, string type) {
+      email = email.ToLowerInvariant();
+      relationship = relationship.ToUpperInvariant();
+      if (!relationships.Contains(relationship)) {
+        throw new ArgumentException("Relationship must be one of: " + string.Join(" ", relationships));
+      }
+
+      string queryString;
+
+      // If type is unspecified, then get all vertices with a given relationship
+      if (string.IsNullOrWhiteSpace(type)) {
+        queryString = GetVertex(email) + GetOutNeighbors(relationship);
+      } else {
+        type = type.ToLowerInvariant();
+        if (!types.Contains(type)) {
+          throw new ArgumentException("Type must be one of: " + string.Join(" ", types));
+        }
+
+        queryString = GetVertex(email) + GetOutNeighbors(relationship) + HasLabel(type);
+      }
+
+      ResultSet<dynamic> result = await DatabaseConnection.Instance.ExecuteQuery(queryString);
+
+      List<dynamic> resultList = await PopulatePlaylistLength(result);
+      resultList = await PopulateVertexOwners(resultList);
+
+      return resultList;
+    }
+
+    public static async Task<ResultSet<dynamic>> UpdateUserVertexQuery(string email, UserVertex u) {
+      email = email.ToLowerInvariant();
+      StringBuilder queryString = new StringBuilder(GetVertex(email));
+
+      try {
+        foreach (PropertyInfo prop in u.GetType().GetProperties()) {
+          // Skip null or empty fields
+          if (prop.GetValue(u) == null || string.IsNullOrWhiteSpace(prop.GetValue(u).ToString())) {
+            continue;
+          }
+
+          queryString.Append(await SetField(prop, "user", email, u).ConfigureAwait(false));
+        }
+
+        // First name and last name must either be:
+        // 1. Both included, or 
+        // 2. Both excluded
+        // in a valid request
+        if ((string.IsNullOrWhiteSpace(u.firstName) && !string.IsNullOrWhiteSpace(u.lastName)) ||
+          (!string.IsNullOrWhiteSpace(u.firstName) && string.IsNullOrWhiteSpace(u.lastName))) {
+          throw new ArgumentException("Both firstName and lastName must be included for name updates");
+        }
+
+        // Append the name field
+        string name = $"{u.firstName} {u.lastName}";
+        queryString.Append(AddProperty("name", name));
+
+        // Append the lowercase searchName field
+        queryString.Append(AddProperty("searchName", name.ToLowerInvariant()));
+      } catch {
+        throw;
+      }
+
+      try {
+        return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
+      } catch {
+        throw;
+      }
+    }
+
+    public static async Task<ResultSet<dynamic>> ReadUserVertexQuery(string email) {
+      email = email.ToLowerInvariant();
+      string queryString = GetVertex(email);
+
+      try {
+        return await DatabaseConnection.Instance.ExecuteQuery(queryString);
+      } catch {
+        throw;
+      }
+    }
+
+    public static async Task<ResultSet<dynamic>> DeleteUserVertexQuery(string email) {
+      email = email.ToLowerInvariant();
+      string queryString = GetVertex(email) + Delete();
+
+      try {
+        // Delete the png or jpg picture associated with this User
+        await StorageConnection.Instance.DeleteFileAsync("user", $"{email}_image.jpg");
+        await StorageConnection.Instance.DeleteFileAsync("user", $"{email}_image.png");
+
+        return await DatabaseConnection.Instance.ExecuteQuery(queryString);
+      } catch {
+        throw;
+      }
+    }
+  }
+}

--- a/brainbeats-backend/GremlinQueries/UserQueries.cs
+++ b/brainbeats-backend/GremlinQueries/UserQueries.cs
@@ -12,46 +12,38 @@ using static brainbeats_backend.Utility;
 namespace brainbeats_backend.GremlinQueries {
   public static class UserQueries {
     private static readonly string defaultProfilePicture = $"{StorageConnection.Instance.StorageEndpoint}/static/profile_picture.png";
-    private static readonly HashSet<string> relationships = new HashSet<string>() { "LIKES", "RECOMMENDED", "OWNED_BY" };
-    private static readonly HashSet<string> types = new HashSet<string>() { "beat", "playlist", "sample" };
+    private static readonly HashSet<string> relationships = new HashSet<string> { "LIKES", "RECOMMENDED", "OWNED_BY" };
+    private static readonly HashSet<string> types = new HashSet<string> { "beat", "playlist", "sample" };
 
     public static async Task<ResultSet<dynamic>> CreateUserVertexQuery(string email, UserVertex u) {
       email = email.ToLowerInvariant();
       StringBuilder queryString = new StringBuilder(CreateVertex("user", email));
 
-      try {
-        foreach (PropertyInfo prop in u.GetType().GetProperties()) {
-          // Skip "image" field for creating new users
-          if (prop.Name.ToLowerInvariant().Equals("image")) {
-            continue;
-          }
-
-          // Skip null or empty fields
-          if (prop.GetValue(u) == null || string.IsNullOrWhiteSpace(prop.GetValue(u).ToString())) {
-            throw new ArgumentException($"{prop.Name} must not be empty");
-          }
-
-          queryString.Append(await SetField(prop, "user", email, u).ConfigureAwait(false));
+      foreach (PropertyInfo prop in u.GetType().GetProperties()) {
+        // Skip "image" field for creating new users
+        if (prop.Name.ToLowerInvariant().Equals("image")) {
+          continue;
         }
 
-        // Append the name field
-        string name = $"{u.firstName} {u.lastName}";
-        queryString.Append(AddProperty("name", name));
+        // Skip null or empty fields
+        if (prop.GetValue(u) == null || string.IsNullOrWhiteSpace(prop.GetValue(u).ToString())) {
+          throw new ArgumentException($"{prop.Name} must not be empty");
+        }
 
-        // Append the lowercase searchName field
-        queryString.Append(AddProperty("searchName", name.ToLowerInvariant()));
-
-        // Attach the default image to new users
-        queryString.Append(AddProperty("image", defaultProfilePicture));
-      } catch {
-        throw;
+        queryString.Append(await SetField(prop, "user", email, u).ConfigureAwait(false));
       }
 
-      try {
-        return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
-      } catch {
-        throw;
-      }
+      // Append the name field
+      string name = $"{u.firstName} {u.lastName}";
+      queryString.Append(AddProperty("name", name));
+
+      // Append the lowercase searchName field
+      queryString.Append(AddProperty("searchName", name.ToLowerInvariant()));
+
+      // Attach the default image to new users
+      queryString.Append(AddProperty("image", defaultProfilePicture));
+
+      return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
     }
 
     public static async Task<dynamic> GetUserVertexNeighborsQuery(string email, string relationship, string type) {
@@ -87,66 +79,50 @@ namespace brainbeats_backend.GremlinQueries {
       email = email.ToLowerInvariant();
       StringBuilder queryString = new StringBuilder(GetVertex(email));
 
-      try {
-        foreach (PropertyInfo prop in u.GetType().GetProperties()) {
-          // Skip null or empty fields
-          if (prop.GetValue(u) == null || string.IsNullOrWhiteSpace(prop.GetValue(u).ToString())) {
-            continue;
-          }
-
-          queryString.Append(await SetField(prop, "user", email, u).ConfigureAwait(false));
+      foreach (PropertyInfo prop in u.GetType().GetProperties()) {
+        // Skip null or empty fields
+        if (prop.GetValue(u) == null || string.IsNullOrWhiteSpace(prop.GetValue(u).ToString())) {
+          continue;
         }
 
-        // First name and last name must either be:
-        // 1. Both included, or 
-        // 2. Both excluded
-        // in a valid request
-        if ((string.IsNullOrWhiteSpace(u.firstName) && !string.IsNullOrWhiteSpace(u.lastName)) ||
-          (!string.IsNullOrWhiteSpace(u.firstName) && string.IsNullOrWhiteSpace(u.lastName))) {
-          throw new ArgumentException("Both firstName and lastName must be included for name updates");
-        }
-
-        // Append the name field
-        string name = $"{u.firstName} {u.lastName}";
-        queryString.Append(AddProperty("name", name));
-
-        // Append the lowercase searchName field
-        queryString.Append(AddProperty("searchName", name.ToLowerInvariant()));
-      } catch {
-        throw;
+        queryString.Append(await SetField(prop, "user", email, u).ConfigureAwait(false));
       }
 
-      try {
-        return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
-      } catch {
-        throw;
+      // First name and last name must either be:
+      // 1. Both included, or 
+      // 2. Both excluded
+      // in a valid request
+      if ((string.IsNullOrWhiteSpace(u.firstName) && !string.IsNullOrWhiteSpace(u.lastName)) ||
+        (!string.IsNullOrWhiteSpace(u.firstName) && string.IsNullOrWhiteSpace(u.lastName))) {
+        throw new ArgumentException("Both firstName and lastName must be included for name updates");
       }
+
+      // Append the name field
+      string name = $"{u.firstName} {u.lastName}";
+      queryString.Append(AddProperty("name", name));
+
+      // Append the lowercase searchName field
+      queryString.Append(AddProperty("searchName", name.ToLowerInvariant()));
+
+      return await DatabaseConnection.Instance.ExecuteQuery(queryString.ToString());
     }
 
     public static async Task<ResultSet<dynamic>> ReadUserVertexQuery(string email) {
       email = email.ToLowerInvariant();
       string queryString = GetVertex(email);
 
-      try {
-        return await DatabaseConnection.Instance.ExecuteQuery(queryString);
-      } catch {
-        throw;
-      }
+      return await DatabaseConnection.Instance.ExecuteQuery(queryString);
     }
 
     public static async Task<ResultSet<dynamic>> DeleteUserVertexQuery(string email) {
       email = email.ToLowerInvariant();
       string queryString = GetVertex(email) + Delete();
 
-      try {
-        // Delete the png or jpg picture associated with this User
-        await StorageConnection.Instance.DeleteFileAsync("user", $"{email}_image.jpg");
-        await StorageConnection.Instance.DeleteFileAsync("user", $"{email}_image.png");
+      // Delete the png or jpg picture associated with this User
+      await StorageConnection.Instance.DeleteFileAsync("user", $"{email}_image.jpg");
+      await StorageConnection.Instance.DeleteFileAsync("user", $"{email}_image.png");
 
-        return await DatabaseConnection.Instance.ExecuteQuery(queryString);
-      } catch {
-        throw;
-      }
+      return await DatabaseConnection.Instance.ExecuteQuery(queryString);
     }
   }
 }

--- a/brainbeats-backend/QueryStrings.cs
+++ b/brainbeats-backend/QueryStrings.cs
@@ -109,7 +109,7 @@ namespace brainbeats_backend {
     }
 
     // Helper method to add a vertex property based on a specific prop
-    private static async Task<string> SetField(PropertyInfo prop, string vertexType, string vertexId, object obj) {
+    public static async Task<string> SetField(PropertyInfo prop, string vertexType, string vertexId, object obj) {
       StringBuilder queryString = new StringBuilder();
       Type type = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
 

--- a/brainbeats-backend/StorageConnection.cs
+++ b/brainbeats-backend/StorageConnection.cs
@@ -1,10 +1,6 @@
 ﻿using Azure.Storage.Blobs;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using static brainbeats_backend.QueryStrings;
 using static brainbeats_backend.QueryStrings;

--- a/brainbeats-backend/brainbeats-backend.csproj.user
+++ b/brainbeats-backend/brainbeats-backend.csproj.user
@@ -5,5 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <ActiveDebugProfile>brainbeats_backend</ActiveDebugProfile>
+    <Controller_SelectedScaffolderID>ApiControllerEmptyScaffolder</Controller_SelectedScaffolderID>
+    <Controller_SelectedScaffolderCategoryPath>root/Controller</Controller_SelectedScaffolderCategoryPath>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
# All APIs rewritten -> api/v2/ Routing
## Summary
- Many overspecialized APIs are now consolidated into single endpoints
- Stopped abusing POST requests, all requests now utilize GET, POST, PUT, and DELETE
- Dedicated folder for query strings split by route type, enhances readability and future expandability, without causing widespread bugs that originate from changing things meant to reflect only a single vertex type
- Note to developers to please migrate to v2 APIs when possible and report any bugs, v1 APIs will no longer be developed and will soon be deprecated entirely at the end of the semester

## v2 API Changes
- Vertex Searches / Reads: All vertices that have an owner now also return the entire user vertex that owns it. You are also now able to search for all liked vertices in a single request, rather than separating requests for beats, playlists, and samples
- Playlist Searches / Reads: All playlist queries now return the playlist length
- More [WIP]